### PR TITLE
Fix Adaptation Issues to Nordic's sdk17

### DIFF
--- a/nrf5_sdk15_platform/flash/ruuvi_nrf5_sdk15_flash.c
+++ b/nrf5_sdk15_platform/flash/ruuvi_nrf5_sdk15_flash.c
@@ -77,7 +77,7 @@ static ruuvi_driver_status_t fds_to_ruuvi_error(ret_code_t err_code)
 {
   switch(err_code)
   {
-    case FDS_SUCCESS:
+    case NRF_SUCCESS:
       return RUUVI_DRIVER_SUCCESS;
 
     case FDS_ERR_OPERATION_TIMEOUT:
@@ -141,7 +141,7 @@ static void fds_evt_handler(fds_evt_t const* p_evt)
   switch(p_evt->id)
   {
     case FDS_EVT_INIT:
-      if(p_evt->result == FDS_SUCCESS)
+      if(p_evt->result == NRF_SUCCESS)
       {
         m_fds_initialized = true;
         ruuvi_interface_log(RUUVI_INTERFACE_LOG_INFO, "FDS init\r\n");
@@ -151,7 +151,7 @@ static void fds_evt_handler(fds_evt_t const* p_evt)
 
     case FDS_EVT_WRITE:
     {
-      if(p_evt->result == FDS_SUCCESS)
+      if(p_evt->result == NRF_SUCCESS)
       {
         ruuvi_interface_log(RUUVI_INTERFACE_LOG_INFO, "Record written\r\n");
         m_fds_processing = false;
@@ -161,7 +161,7 @@ static void fds_evt_handler(fds_evt_t const* p_evt)
 
     case FDS_EVT_UPDATE:
     {
-      if(p_evt->result == FDS_SUCCESS)
+      if(p_evt->result == NRF_SUCCESS)
       {
         ruuvi_interface_log(RUUVI_INTERFACE_LOG_INFO, "Record updated\r\n");
         m_fds_processing = false;
@@ -171,7 +171,7 @@ static void fds_evt_handler(fds_evt_t const* p_evt)
 
     case FDS_EVT_DEL_RECORD:
     {
-      if(p_evt->result == FDS_SUCCESS)
+      if(p_evt->result == NRF_SUCCESS)
       {
         ruuvi_interface_log(RUUVI_INTERFACE_LOG_INFO, "Record deleted\r\n");
         m_fds_processing = false;
@@ -181,7 +181,7 @@ static void fds_evt_handler(fds_evt_t const* p_evt)
 
     case FDS_EVT_DEL_FILE:
     {
-      if(p_evt->result == FDS_SUCCESS)
+      if(p_evt->result == NRF_SUCCESS)
       {
         ruuvi_interface_log(RUUVI_INTERFACE_LOG_INFO, "File deleted\r\n");
         m_fds_processing = false;
@@ -191,7 +191,7 @@ static void fds_evt_handler(fds_evt_t const* p_evt)
 
     case FDS_EVT_GC:
     {
-      if(p_evt->result == FDS_SUCCESS)
+      if(p_evt->result == NRF_SUCCESS)
       {
         ruuvi_interface_log(RUUVI_INTERFACE_LOG_INFO, "Garbage collected\r\n");
         m_fds_processing = false;
@@ -275,7 +275,7 @@ ruuvi_driver_status_t ruuvi_interface_flash_record_delete(const uint32_t page_id
   };
   ret_code_t rc = fds_record_find(page_id, record_id, &desc, &tok);
 
-  if(FDS_SUCCESS == rc)
+  if(NRF_SUCCESS == rc)
   {
     rc = fds_record_delete(&desc);
   }
@@ -321,7 +321,7 @@ ruuvi_driver_status_t ruuvi_interface_flash_record_set(const uint32_t page_id,
   ret_code_t rc = fds_record_find(page_id, record_id, &desc, &tok);
 
   // If record was found
-  if(FDS_SUCCESS == rc)
+  if(NRF_SUCCESS == rc)
   {
     /* Start write */
     m_fds_processing = true;
@@ -386,7 +386,7 @@ ruuvi_driver_status_t ruuvi_interface_flash_record_get(const uint32_t page_id,
   err_code |= fds_to_ruuvi_error(rc);
 
   // If file was found
-  if(FDS_SUCCESS == rc)
+  if(NRF_SUCCESS == rc)
   {
     fds_flash_record_t record = {0};
     /* Open the record and read its contents. */

--- a/nrf5_sdk15_platform/gpio/ruuvi_nrf5_sdk15_gpio.c
+++ b/nrf5_sdk15_platform/gpio/ruuvi_nrf5_sdk15_gpio.c
@@ -30,7 +30,7 @@ static bool m_gpio_is_init = false;
  */
 static inline uint8_t ruuvi_to_nrf_pin_map(const ruuvi_interface_gpio_id_t pin)
 {
-  return (pin.port_pin.port << 5) + pin.port_pin.pin;
+  return (pin.pin >> 8U) + (pin.pin & 0x1FU);
 }
 
 /**

--- a/nrf5_sdk15_platform/gpio/ruuvi_nrf5_sdk15_gpio.h
+++ b/nrf5_sdk15_platform/gpio/ruuvi_nrf5_sdk15_gpio.h
@@ -22,7 +22,7 @@
  */
 static inline uint8_t ruuvi_to_nrf_pin_map(const ruuvi_interface_gpio_id_t pin)
 {
-  return (pin.port_pin.port << 5) + pin.port_pin.pin;
+  return (pin.pin >> 8U) + (pin.pin & 0x1FU);
 }
 /*@}*/
 #endif

--- a/nrf5_sdk15_platform/sdk_config.h
+++ b/nrf5_sdk15_platform/sdk_config.h
@@ -1749,6 +1749,15 @@
   #define FDS_VIRTUAL_PAGE_SIZE 1024
 #endif
 
+// <o> FDS_VIRTUAL_PAGES_RESERVED - The number of virtual flash pages that are used by other modules. 
+// <i> FDS module stores its data in the last pages of the flash memory.
+// <i> By setting this value, you can move flash end address used by the FDS.
+// <i> As a result the reserved space can be used by other modules.
+
+#ifndef FDS_VIRTUAL_PAGES_RESERVED
+#define FDS_VIRTUAL_PAGES_RESERVED 0
+#endif
+
 // </h>
 //==========================================================
 


### PR DESCRIPTION
As of Nordic's SDK16, the NRF_SUCCESS is now used instead of FDS_SUCCESS and sdk_config.h requires configuration for FDS_VIRTUAL_PAGES_RESERVED. Also fix for GPIO port issues, where GPIO port is not set properly.