### PR TITLE
Add dps310

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "STMems_Standard_C_drivers"]
 	path = STMems_Standard_C_drivers
 	url = https://github.com/ojousima/STMems_Standard_C_drivers
+[submodule "ruuvi.dps310.c"]
+	path = ruuvi.dps310.c
+	url = https://github.com/ruuvi/ruuvi.dps310.c

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: c
 os: linux
-dist: trusty
+dist: bionic
 git:
   depth: false
 before_install:
@@ -14,6 +14,7 @@ install:
   && sudo apt-get install -qq
 - sudo apt-get install -qq pvs-studio
 - sudo apt-get install -qq doxygen
+- sudo apt install openjdk-11-jdk
 - gem install ceedling
 - pvs-studio-analyzer credentials $PVS_USERNAME $PVS_KEY
 - |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 3.5.0
+ - Add partial DPS310 support (SPI only, no FIFO, no interrupts)
+
 ## 3.4.5
  - Fix GPIO port mapping on NRF5 SDK 15 when port > 0.
  - Fix Flash erase not clearing out everything on nRF5 SDK15.

--- a/Makefile
+++ b/Makefile
@@ -240,9 +240,9 @@ TAG := $(shell git describe --tags --exact-match)
 COMMIT := $(shell git rev-parse --short HEAD)
 VERSION := $(if $(TAG),$(TAG),$(COMMIT))
 
-.PHONY: clean doxygen
+.PHONY: astyle clean doxygen
 
-all: clean doxygen $(SOURCES) $(EXECUTABLE) 
+all: clean astyle doxygen $(SOURCES) $(EXECUTABLE) 
 
 $(EXECUTABLE): $(OBJECTS)
 # Converting

--- a/project.yml
+++ b/project.yml
@@ -62,6 +62,7 @@
   :enforce_strict_ordering: TRUE
   :plugins:
     - :ignore
+    - :ignore_arg
     - :callback
     - :return_thru_ptr
     - :array

--- a/project.yml
+++ b/project.yml
@@ -35,6 +35,7 @@
   :source:
     - BME280_driver/*
     - BME280_driver/selftest/*
+    - ruuvi.dps310.c/*
     - src/*
     - src/tasks/**
     - src/interfaces/**

--- a/src/integration_tests/ruuvi_driver_sensor_test.c
+++ b/src/integration_tests/ruuvi_driver_sensor_test.c
@@ -391,8 +391,7 @@ static bool sensor_sleeps_after_init (const rd_sensor_t * const DUT)
     return false;
 }
 
-static bool sensor_returns_invalid_before_sampling (const rd_sensor_t * const
-        DUT)
+static bool sensor_returns_invalid_before_sampling (const rd_sensor_t * const DUT)
 {
     rd_status_t err_code = RD_SUCCESS;
     float values_new[MAX_SENSOR_PROVIDED_FIELDS];

--- a/src/interfaces/environmental/ruuvi_interface_dps310.c
+++ b/src/interfaces/environmental/ruuvi_interface_dps310.c
@@ -1,0 +1,156 @@
+#include "ruuvi_interface_dps310.h"
+#include "dps310.h"
+#include "ruuvi_driver_error.h"
+#include "ruuvi_driver_sensor.h"
+#include "ruuvi_interface_spi_dps310.h"
+#include "ruuvi_interface_yield.h"
+
+// Singleton access for compatibility with other driver implementations.
+static dps310_ctx_t singleton_ctx_spi =
+{
+    .write = &ri_spi_dps310_write,
+    .read  = &ri_spi_dps310_read,
+    .sleep = &ri_delay_ms
+};
+static uint8_t singleton_comm_ctx;
+static const char * const name = "DPS310";
+
+static __attribute__ ( (nonnull))
+rd_status_t dps310_singleton_setup (rd_sensor_t * const p_sensor, const rd_bus_t bus)
+{
+    rd_status_t err_code = RD_SUCCESS;
+
+    if (RD_BUS_SPI == bus)
+    {
+        p_sensor->p_ctx = &singleton_ctx_spi;
+    }
+    else if (RD_BUS_I2C == bus)
+    {
+        err_code |= RD_ERROR_NOT_IMPLEMENTED;
+    }
+    else
+    {
+        err_code |= RD_ERROR_NOT_SUPPORTED;
+    }
+
+    return err_code;
+}
+
+static __attribute__ ( (nonnull))
+void dps310_fp_setup (rd_sensor_t * const p_sensor)
+{
+    p_sensor->init = &ri_dps310_init;
+    p_sensor->uninit = &ri_dps310_uninit;
+    p_sensor->samplerate_set = &ri_dps310_samplerate_set;
+    p_sensor->samplerate_get = &ri_dps310_samplerate_get;
+    p_sensor->resolution_set = &ri_dps310_resolution_set;
+    p_sensor->resolution_get = &ri_dps310_resolution_get;
+    p_sensor->scale_set = &ri_dps310_scale_set;
+    p_sensor->scale_get = &ri_dps310_scale_get;
+    p_sensor->dsp_set = &ri_dps310_dsp_set;
+    p_sensor->dsp_get = &ri_dps310_dsp_get;
+    p_sensor->mode_set = &ri_dps310_mode_set;
+    p_sensor->mode_get = &ri_dps310_mode_get;
+    p_sensor->data_get = &ri_dps310_data_get;
+    return;
+}
+
+rd_status_t ri_dps310_init (rd_sensor_t * p_sensor, rd_bus_t bus, uint8_t handle)
+{
+    rd_status_t err_code = RD_SUCCESS;
+    dps310_status_t dps_status = DPS310_SUCCESS;
+
+    if (NULL == p_sensor)
+    {
+        err_code |= RD_ERROR_NULL;
+    }
+    else if (rd_sensor_is_init (p_sensor))
+    {
+        err_code |= RD_ERROR_INVALID_STATE;
+    }
+    else
+    {
+        if (NULL == p_sensor->p_ctx)
+        {
+            dps310_singleton_setup (p_sensor, bus);
+        }
+
+        if (RD_SUCCESS == err_code)
+        {
+            dps_status = dps310_init (p_sensor->p_ctx);
+
+            if (DPS310_SUCCESS == dps_status)
+            {
+                rd_sensor_initialize (p_sensor);
+                dps310_fp_setup (p_sensor);
+                p_sensor->name = name;
+            }
+            else
+            {
+                err_code |= RD_ERROR_NOT_FOUND;
+            }
+        }
+    }
+
+    return err_code;
+}
+
+rd_status_t ri_dps310_uninit (rd_sensor_t * sensor, rd_bus_t bus, uint8_t handle)
+{
+    return RD_ERROR_NOT_IMPLEMENTED;
+}
+
+rd_status_t ri_dps310_samplerate_set (uint8_t * samplerate)
+{
+    return RD_ERROR_NOT_IMPLEMENTED;
+}
+
+rd_status_t ri_dps310_samplerate_get (uint8_t * samplerate)
+{
+    return RD_ERROR_NOT_IMPLEMENTED;
+}
+
+rd_status_t ri_dps310_resolution_set (uint8_t * resolution)
+{
+    return RD_ERROR_NOT_IMPLEMENTED;
+}
+
+rd_status_t ri_dps310_resolution_get (uint8_t * resolution)
+{
+    return RD_ERROR_NOT_IMPLEMENTED;
+}
+
+rd_status_t ri_dps310_scale_set (uint8_t * scale)
+{
+    return RD_ERROR_NOT_IMPLEMENTED;
+}
+
+rd_status_t ri_dps310_scale_get (uint8_t * scale)
+{
+    return RD_ERROR_NOT_IMPLEMENTED;
+}
+
+rd_status_t ri_dps310_dsp_set (uint8_t * dsp, uint8_t * parameter)
+{
+    return RD_ERROR_NOT_IMPLEMENTED;
+}
+
+rd_status_t ri_dps310_dsp_get (uint8_t * dsp, uint8_t * parameter)
+{
+    return RD_ERROR_NOT_IMPLEMENTED;
+}
+
+rd_status_t ri_dps310_mode_set (uint8_t * mode)
+{
+    return RD_ERROR_NOT_IMPLEMENTED;
+}
+
+rd_status_t ri_dps310_mode_get (uint8_t * mode)
+{
+    return RD_ERROR_NOT_IMPLEMENTED;
+}
+
+rd_status_t ri_dps310_data_get (rd_sensor_data_t * const data)
+{
+    return RD_ERROR_NOT_IMPLEMENTED;
+}

--- a/src/interfaces/environmental/ruuvi_interface_dps310.c
+++ b/src/interfaces/environmental/ruuvi_interface_dps310.c
@@ -32,7 +32,7 @@ static ri_dps310_measurement_t last_data;
 
 static __attribute__ ( (nonnull)) void
 dps310_singleton_spi_setup (rd_sensor_t * const p_sensor,
-                             const uint8_t handle)
+                            const uint8_t handle)
 {
     p_sensor->p_ctx = &singleton_ctx_spi;
     spi_comm_handle = handle;
@@ -74,11 +74,11 @@ rd_status_t ri_dps310_init (rd_sensor_t * p_sensor, rd_bus_t bus, uint8_t handle
     {
         if (NULL == p_sensor->p_ctx)
         {
-            if(RD_BUS_SPI == bus)
+            if (RD_BUS_SPI == bus)
             {
                 dps310_singleton_spi_setup (p_sensor, handle);
             }
-            else if(RD_BUS_I2C == bus)
+            else if (RD_BUS_I2C == bus)
             {
                 err_code |= RD_ERROR_NOT_IMPLEMENTED;
             }
@@ -658,7 +658,6 @@ rd_status_t ri_dps310_mode_set (uint8_t * mode)
                       &last_data.temperature_c);
         dps_status |= dps310_measure_pres_once_sync (&singleton_ctx_spi, &last_data.pressure_pa);
         last_data.timestamp_ms = rd_sensor_timestamp_get();
-        *mode = RD_SENSOR_CFG_SLEEP;
     }
     else if (RD_SENSOR_CFG_CONTINUOUS == *mode)
     {
@@ -674,6 +673,7 @@ rd_status_t ri_dps310_mode_set (uint8_t * mode)
         err_code |= RD_ERROR_INTERNAL;
     }
 
+    err_code |= ri_dps310_mode_get (mode);
     return err_code;
 }
 

--- a/src/interfaces/environmental/ruuvi_interface_dps310.c
+++ b/src/interfaces/environmental/ruuvi_interface_dps310.c
@@ -126,12 +126,196 @@ rd_status_t ri_dps310_uninit (rd_sensor_t * sensor, rd_bus_t bus, uint8_t handle
 
 rd_status_t ri_dps310_samplerate_set (uint8_t * samplerate)
 {
-    return RD_ERROR_NOT_IMPLEMENTED;
+    rd_status_t err_code = RD_SUCCESS;
+    dps310_status_t dps_status = DPS310_SUCCESS;
+
+    if (NULL == samplerate)
+    {
+        err_code |= RD_ERROR_NULL;
+    }
+    else if (RD_SENSOR_CFG_NO_CHANGE == *samplerate)
+    {
+        // No action needed.
+    }
+    else if (RD_SENSOR_CFG_DEFAULT == *samplerate)
+    {
+        dps_status |= dps310_config_temp (&singleton_ctx_spi,
+                                          DPS310_DEFAULT_MR,
+                                          singleton_ctx_spi.temp_osr);
+        dps_status |= dps310_config_pres (&singleton_ctx_spi,
+                                          DPS310_DEFAULT_MR,
+                                          singleton_ctx_spi.pres_osr);
+    }
+    else if ( (RD_SENSOR_CFG_MIN == *samplerate) || (1U == *samplerate))
+    {
+        dps_status |= dps310_config_temp (&singleton_ctx_spi,
+                                          DPS310_MR_1,
+                                          singleton_ctx_spi.temp_osr);
+        dps_status |= dps310_config_pres (&singleton_ctx_spi,
+                                          DPS310_MR_1,
+                                          singleton_ctx_spi.pres_osr);
+    }
+    else if (RD_SENSOR_CFG_MAX == *samplerate)
+    {
+        dps_status |= dps310_config_temp (&singleton_ctx_spi,
+                                          DPS310_MR_128,
+                                          singleton_ctx_spi.temp_osr);
+        dps_status |= dps310_config_pres (&singleton_ctx_spi,
+                                          DPS310_MR_128,
+                                          singleton_ctx_spi.pres_osr);
+    }
+    else if (2U == *samplerate)
+    {
+        dps_status |= dps310_config_temp (&singleton_ctx_spi,
+                                          DPS310_MR_2,
+                                          singleton_ctx_spi.temp_osr);
+        dps_status |= dps310_config_pres (&singleton_ctx_spi,
+                                          DPS310_MR_2,
+                                          singleton_ctx_spi.pres_osr);
+    }
+    else if (4U >= *samplerate)
+    {
+        dps_status |= dps310_config_temp (&singleton_ctx_spi,
+                                          DPS310_MR_4,
+                                          singleton_ctx_spi.temp_osr);
+        dps_status |= dps310_config_pres (&singleton_ctx_spi,
+                                          DPS310_MR_4,
+                                          singleton_ctx_spi.pres_osr);
+    }
+    else if (8U >= *samplerate)
+    {
+        dps_status |= dps310_config_temp (&singleton_ctx_spi,
+                                          DPS310_MR_8,
+                                          singleton_ctx_spi.temp_osr);
+        dps_status |= dps310_config_pres (&singleton_ctx_spi,
+                                          DPS310_MR_8,
+                                          singleton_ctx_spi.pres_osr);
+    }
+    else if (16U >= *samplerate)
+    {
+        dps_status |= dps310_config_temp (&singleton_ctx_spi,
+                                          DPS310_MR_16,
+                                          singleton_ctx_spi.temp_osr);
+        dps_status |= dps310_config_pres (&singleton_ctx_spi,
+                                          DPS310_MR_16,
+                                          singleton_ctx_spi.pres_osr);
+    }
+    else if (32U >= *samplerate)
+    {
+        dps_status |= dps310_config_temp (&singleton_ctx_spi,
+                                          DPS310_MR_32,
+                                          singleton_ctx_spi.temp_osr);
+        dps_status |= dps310_config_pres (&singleton_ctx_spi,
+                                          DPS310_MR_32,
+                                          singleton_ctx_spi.pres_osr);
+    }
+    else if (64U >= *samplerate)
+    {
+        dps_status |= dps310_config_temp (&singleton_ctx_spi,
+                                          DPS310_MR_64,
+                                          singleton_ctx_spi.temp_osr);
+        dps_status |= dps310_config_pres (&singleton_ctx_spi,
+                                          DPS310_MR_64,
+                                          singleton_ctx_spi.pres_osr);
+    }
+    else if (128U >= *samplerate)
+    {
+        dps_status |= dps310_config_temp (&singleton_ctx_spi,
+                                          DPS310_MR_128,
+                                          singleton_ctx_spi.temp_osr);
+        dps_status |= dps310_config_pres (&singleton_ctx_spi,
+                                          DPS310_MR_128,
+                                          singleton_ctx_spi.pres_osr);
+    }
+    else
+    {
+        err_code |= RD_ERROR_NOT_SUPPORTED;
+    }
+
+    if (DPS310_SUCCESS == dps_status)
+    {
+        err_code |= ri_dps310_samplerate_get (samplerate);
+    }
+    else
+    {
+        err_code |= RD_ERROR_INTERNAL;
+    }
+
+    return err_code;
+}
+
+static uint8_t dps310_mr_to_samplerate (const dps310_mr_t mr)
+{
+    uint8_t rate;
+
+    switch (mr)
+    {
+        case DPS310_MR_1:
+            rate = 1U;
+            break;
+
+        case DPS310_MR_2:
+            rate = 2U;
+            break;
+
+        case DPS310_MR_4:
+            rate = 4U;
+            break;
+
+        case DPS310_MR_8:
+            rate = 8U;
+            break;
+
+        case DPS310_MR_16:
+            rate = 16U;
+            break;
+
+        case DPS310_MR_32:
+            rate = 32U;
+            break;
+
+        case DPS310_MR_64:
+            rate = 64U;
+            break;
+
+        case DPS310_MR_128:
+            rate = 128U;
+            break;
+
+        default:
+            rate = 0U;
+            break;
+    }
+
+    return rate;
 }
 
 rd_status_t ri_dps310_samplerate_get (uint8_t * samplerate)
 {
-    return RD_ERROR_NOT_IMPLEMENTED;
+    rd_status_t err_code = RD_SUCCESS;
+    uint8_t rate = 0U;
+
+    if (NULL == samplerate)
+    {
+        err_code |= RD_ERROR_NULL;
+    }
+    else
+    {
+        // Separate rates for temperature and pressure aren't supported
+        // by interface, so can check only temperature rate.
+        rate = dps310_mr_to_samplerate (singleton_ctx_spi.temp_mr);
+    }
+
+    if (0U == rate)
+    {
+        err_code |= RD_ERROR_INTERNAL;
+    }
+    else
+    {
+        *samplerate = rate;
+    }
+
+    return err_code;
 }
 
 rd_status_t ri_dps310_resolution_set (uint8_t * resolution)

--- a/src/interfaces/environmental/ruuvi_interface_dps310.c
+++ b/src/interfaces/environmental/ruuvi_interface_dps310.c
@@ -1,4 +1,5 @@
 #include "ruuvi_interface_dps310.h"
+#include "ruuvi_driver_enabled_modules.h"
 #include "dps310.h"
 #include "ruuvi_driver_error.h"
 #include "ruuvi_driver_sensor.h"
@@ -6,6 +7,8 @@
 #include "ruuvi_interface_yield.h"
 #include <stdint.h>
 #include <string.h>
+
+#if (RI_DPS310_ENABLED || DOXYGEN)
 
 static void dps_sleep (const uint32_t ms)
 {
@@ -762,3 +765,5 @@ rd_status_t ri_dps310_data_get (rd_sensor_data_t * const data)
 
     return err_code;
 }
+
+#endif

--- a/src/interfaces/environmental/ruuvi_interface_dps310.c
+++ b/src/interfaces/environmental/ruuvi_interface_dps310.c
@@ -22,11 +22,12 @@ static dps310_ctx_t singleton_ctx_spi =
 };
 static uint8_t singleton_comm_ctx;
 static const char * const name = "DPS310";
-typedef struct {
+typedef struct
+{
     uint64_t timestamp_ms;
     float pressure_pa;
     float temperature_c;
-}ri_dps310_measurement_t;
+} ri_dps310_measurement_t;
 static ri_dps310_measurement_t last_data;
 
 static __attribute__ ( (nonnull)) rd_status_t
@@ -651,14 +652,15 @@ rd_status_t ri_dps310_mode_set (uint8_t * mode)
 {
     rd_status_t err_code = RD_SUCCESS;
     dps310_status_t dps_status = DPS310_SUCCESS;
-    if(NULL == mode)
+
+    if (NULL == mode)
     {
         err_code |= RD_ERROR_NULL;
     }
-    else if ((RD_SENSOR_CFG_SLEEP == *mode)
-            || (RD_SENSOR_CFG_DEFAULT == *mode))
+    else if ( (RD_SENSOR_CFG_SLEEP == *mode)
+              || (RD_SENSOR_CFG_DEFAULT == *mode))
     {
-        dps_status = dps310_standby(&singleton_ctx_spi);
+        dps_status = dps310_standby (&singleton_ctx_spi);
     }
     else if (DPS310_READY != singleton_ctx_spi.device_status)
     {
@@ -666,14 +668,15 @@ rd_status_t ri_dps310_mode_set (uint8_t * mode)
     }
     else if (RD_SENSOR_CFG_SINGLE == *mode)
     {
-        dps_status |= dps310_measure_temp_once_sync (&singleton_ctx_spi, &last_data.temperature_c);
+        dps_status |= dps310_measure_temp_once_sync (&singleton_ctx_spi,
+                      &last_data.temperature_c);
         dps_status |= dps310_measure_pres_once_sync (&singleton_ctx_spi, &last_data.pressure_pa);
         last_data.timestamp_ms = rd_sensor_timestamp_get();
         *mode = RD_SENSOR_CFG_SLEEP;
     }
     else if (RD_SENSOR_CFG_CONTINUOUS == *mode)
     {
-        dps_status |= dps310_measure_continuous_async(&singleton_ctx_spi);
+        dps_status |= dps310_measure_continuous_async (&singleton_ctx_spi);
     }
     else
     {
@@ -691,13 +694,14 @@ rd_status_t ri_dps310_mode_set (uint8_t * mode)
 rd_status_t ri_dps310_mode_get (uint8_t * mode)
 {
     rd_status_t err_code = RD_SUCCESS;
-    if(NULL == mode)
+
+    if (NULL == mode)
     {
         err_code |= RD_ERROR_NULL;
     }
     else
     {
-        switch(singleton_ctx_spi.device_status)
+        switch (singleton_ctx_spi.device_status)
         {
             case DPS310_READY:
                 *mode = RD_SENSOR_CFG_SLEEP;

--- a/src/interfaces/environmental/ruuvi_interface_dps310.c
+++ b/src/interfaces/environmental/ruuvi_interface_dps310.c
@@ -24,7 +24,7 @@ static dps310_ctx_t singleton_ctx_spi =
     .sleep = &dps_sleep,
     .comm_ctx = &spi_comm_handle
 };
-static uint8_t singleton_comm_ctx;
+
 static const char * const name = "DPS310";
 const rd_sensor_data_fields_t dps_fields =
 {
@@ -117,7 +117,6 @@ rd_status_t ri_dps310_init (rd_sensor_t * p_sensor, rd_bus_t bus, uint8_t handle
 rd_status_t ri_dps310_uninit (rd_sensor_t * sensor, rd_bus_t bus, uint8_t handle)
 {
     rd_status_t err_code = RD_SUCCESS;
-    dps310_status_t dps_status = DPS310_SUCCESS;
 
     if (NULL == sensor)
     {
@@ -337,7 +336,6 @@ rd_status_t ri_dps310_samplerate_get (uint8_t * samplerate)
 rd_status_t ri_dps310_resolution_set (uint8_t * resolution)
 {
     rd_status_t err_code = RD_SUCCESS;
-    dps310_status_t dps_status = DPS310_SUCCESS;
 
     if (NULL == resolution)
     {
@@ -366,7 +364,6 @@ rd_status_t ri_dps310_resolution_set (uint8_t * resolution)
 rd_status_t ri_dps310_resolution_get (uint8_t * resolution)
 {
     rd_status_t err_code = RD_SUCCESS;
-    dps310_status_t dps_status = DPS310_SUCCESS;
 
     if (NULL == resolution)
     {
@@ -383,7 +380,6 @@ rd_status_t ri_dps310_resolution_get (uint8_t * resolution)
 rd_status_t ri_dps310_scale_set (uint8_t * scale)
 {
     rd_status_t err_code = RD_SUCCESS;
-    dps310_status_t dps_status = DPS310_SUCCESS;
 
     if (NULL == scale)
     {
@@ -412,7 +408,6 @@ rd_status_t ri_dps310_scale_set (uint8_t * scale)
 rd_status_t ri_dps310_scale_get (uint8_t * scale)
 {
     rd_status_t err_code = RD_SUCCESS;
-    dps310_status_t dps_status = DPS310_SUCCESS;
 
     if (NULL == scale)
     {
@@ -732,7 +727,7 @@ rd_status_t ri_dps310_mode_get (uint8_t * mode)
 rd_status_t ri_dps310_data_get (rd_sensor_data_t * const data)
 {
     rd_status_t err_code = RD_SUCCESS;
-    uint8_t mode;
+    uint8_t mode = RD_SENSOR_CFG_DEFAULT;
     (void) ri_dps310_mode_get (&mode);
 
     if (NULL == data)

--- a/src/interfaces/environmental/ruuvi_interface_dps310.c
+++ b/src/interfaces/environmental/ruuvi_interface_dps310.c
@@ -422,12 +422,223 @@ rd_status_t ri_dps310_scale_get (uint8_t * scale)
 
 rd_status_t ri_dps310_dsp_set (uint8_t * dsp, uint8_t * parameter)
 {
-    return RD_ERROR_NOT_IMPLEMENTED;
+    rd_status_t err_code = RD_SUCCESS;
+    dps310_status_t dps_status = DPS310_SUCCESS;
+
+    if ( (NULL == dsp) || (NULL == parameter))
+    {
+        err_code |= RD_ERROR_NULL;
+    }
+    else if (DPS310_READY != singleton_ctx_spi.device_status)
+    {
+        err_code |= RD_ERROR_INVALID_STATE;
+    }
+    else if ( (RD_SENSOR_DSP_LAST == *dsp)
+              || (RD_SENSOR_CFG_DEFAULT == *dsp))
+    {
+        dps_status |= dps310_config_temp (&singleton_ctx_spi,
+                                          singleton_ctx_spi.temp_mr,
+                                          DPS310_OS_1);
+        dps_status |= dps310_config_pres (&singleton_ctx_spi,
+                                          singleton_ctx_spi.pres_mr,
+                                          DPS310_OS_1);
+    }
+    else if (RD_SENSOR_DSP_OS == *dsp)
+    {
+        if (RD_SENSOR_CFG_NO_CHANGE == *parameter)
+        {
+            // No action needed.
+        }
+        else if (RD_SENSOR_CFG_DEFAULT == *parameter)
+        {
+            dps_status |= dps310_config_temp (&singleton_ctx_spi,
+                                              singleton_ctx_spi.temp_mr,
+                                              DPS310_DEFAULT_OS);
+            dps_status |= dps310_config_pres (&singleton_ctx_spi,
+                                              singleton_ctx_spi.pres_mr,
+                                              DPS310_DEFAULT_OS);
+        }
+        else if ( (RD_SENSOR_CFG_MIN == *parameter) || (1U == *parameter))
+        {
+            dps_status |= dps310_config_temp (&singleton_ctx_spi,
+                                              singleton_ctx_spi.temp_mr,
+                                              DPS310_OS_1);
+            dps_status |= dps310_config_pres (&singleton_ctx_spi,
+                                              singleton_ctx_spi.pres_mr,
+                                              DPS310_OS_1);
+        }
+        else if (RD_SENSOR_CFG_MAX == *parameter)
+        {
+            dps_status |= dps310_config_temp (&singleton_ctx_spi,
+                                              singleton_ctx_spi.temp_mr,
+                                              DPS310_OS_128);
+            dps_status |= dps310_config_pres (&singleton_ctx_spi,
+                                              singleton_ctx_spi.pres_mr,
+                                              DPS310_OS_128);
+        }
+        else if (2U == *parameter)
+        {
+            dps_status |= dps310_config_temp (&singleton_ctx_spi,
+                                              singleton_ctx_spi.temp_mr,
+                                              DPS310_OS_2);
+            dps_status |= dps310_config_pres (&singleton_ctx_spi,
+                                              singleton_ctx_spi.pres_mr,
+                                              DPS310_OS_2);
+        }
+        else if (4U >= *parameter)
+        {
+            dps_status |= dps310_config_temp (&singleton_ctx_spi,
+                                              singleton_ctx_spi.temp_mr,
+                                              DPS310_OS_4);
+            dps_status |= dps310_config_pres (&singleton_ctx_spi,
+                                              singleton_ctx_spi.pres_mr,
+                                              DPS310_OS_4);
+        }
+        else if (8U >= *parameter)
+        {
+            dps_status |= dps310_config_temp (&singleton_ctx_spi,
+                                              singleton_ctx_spi.temp_mr,
+                                              DPS310_OS_8);
+            dps_status |= dps310_config_pres (&singleton_ctx_spi,
+                                              singleton_ctx_spi.pres_mr,
+                                              DPS310_OS_8);
+        }
+        else if (16U >= *parameter)
+        {
+            dps_status |= dps310_config_temp (&singleton_ctx_spi,
+                                              singleton_ctx_spi.temp_mr,
+                                              DPS310_OS_16);
+            dps_status |= dps310_config_pres (&singleton_ctx_spi,
+                                              singleton_ctx_spi.pres_mr,
+                                              DPS310_OS_16);
+        }
+        else if (32U >= *parameter)
+        {
+            dps_status |= dps310_config_temp (&singleton_ctx_spi,
+                                              singleton_ctx_spi.temp_mr,
+                                              DPS310_OS_32);
+            dps_status |= dps310_config_pres (&singleton_ctx_spi,
+                                              singleton_ctx_spi.pres_mr,
+                                              DPS310_OS_32);
+        }
+        else if (64U >= *parameter)
+        {
+            dps_status |= dps310_config_temp (&singleton_ctx_spi,
+                                              singleton_ctx_spi.temp_mr,
+                                              DPS310_OS_64);
+            dps_status |= dps310_config_pres (&singleton_ctx_spi,
+                                              singleton_ctx_spi.pres_mr,
+                                              DPS310_OS_64);
+        }
+        else if (128U >= *parameter)
+        {
+            dps_status |= dps310_config_temp (&singleton_ctx_spi,
+                                              singleton_ctx_spi.temp_mr,
+                                              DPS310_OS_128);
+            dps_status |= dps310_config_pres (&singleton_ctx_spi,
+                                              singleton_ctx_spi.pres_mr,
+                                              DPS310_OS_128);
+        }
+        else
+        {
+            err_code |= RD_ERROR_NOT_SUPPORTED;
+        }
+    }
+
+    if (DPS310_SUCCESS == dps_status)
+    {
+        err_code |= ri_dps310_dsp_get (dsp, parameter);
+    }
+    else
+    {
+        err_code |= RD_ERROR_INTERNAL;
+    }
+
+    return err_code;
+}
+
+static uint8_t dps310_os_to_samplerate (const dps310_os_t os)
+{
+    uint8_t rate;
+
+    switch (os)
+    {
+        case DPS310_OS_1:
+            rate = 1U;
+            break;
+
+        case DPS310_OS_2:
+            rate = 2U;
+            break;
+
+        case DPS310_OS_4:
+            rate = 4U;
+            break;
+
+        case DPS310_OS_8:
+            rate = 8U;
+            break;
+
+        case DPS310_OS_16:
+            rate = 16U;
+            break;
+
+        case DPS310_OS_32:
+            rate = 32U;
+            break;
+
+        case DPS310_OS_64:
+            rate = 64U;
+            break;
+
+        case DPS310_OS_128:
+            rate = 128U;
+            break;
+
+        default:
+            rate = 0U;
+            break;
+    }
+
+    return rate;
 }
 
 rd_status_t ri_dps310_dsp_get (uint8_t * dsp, uint8_t * parameter)
 {
-    return RD_ERROR_NOT_IMPLEMENTED;
+    rd_status_t err_code = RD_SUCCESS;
+    uint8_t sampling = 0;
+
+    // Separate rates for temperature and pressure aren't supported
+    // by interface, so can check only temperature rate.
+    if ( (NULL == dsp) || (NULL == parameter))
+    {
+        err_code |= RD_ERROR_NULL;
+    }
+    else if (singleton_ctx_spi.temp_osr > DPS310_OS_1)
+    {
+        sampling = dps310_os_to_samplerate (singleton_ctx_spi.temp_osr);
+
+        if (sampling > 1)
+        {
+            *dsp = RD_SENSOR_DSP_OS;
+            *parameter = sampling;
+        }
+        else
+        {
+            err_code = RD_ERROR_INTERNAL;
+        }
+    }
+    else if (singleton_ctx_spi.temp_osr == DPS310_OS_1)
+    {
+        *dsp = RD_SENSOR_CFG_DEFAULT;
+        *parameter = 1U;
+    }
+    else
+    {
+        err_code = RD_ERROR_INTERNAL;
+    }
+
+    return err_code;
 }
 
 rd_status_t ri_dps310_mode_set (uint8_t * mode)

--- a/src/interfaces/environmental/ruuvi_interface_dps310.c
+++ b/src/interfaces/environmental/ruuvi_interface_dps310.c
@@ -76,6 +76,8 @@ rd_status_t ri_dps310_init (rd_sensor_t * p_sensor, rd_bus_t bus, uint8_t handle
     }
     else
     {
+        rd_sensor_initialize (p_sensor);
+
         if (NULL == p_sensor->p_ctx)
         {
             if (RD_BUS_SPI == bus)
@@ -98,7 +100,6 @@ rd_status_t ri_dps310_init (rd_sensor_t * p_sensor, rd_bus_t bus, uint8_t handle
 
             if (DPS310_SUCCESS == dps_status)
             {
-                rd_sensor_initialize (p_sensor);
                 dps310_fp_setup (p_sensor);
                 p_sensor->name = name;
                 p_sensor->provides = dps_fields;

--- a/src/interfaces/environmental/ruuvi_interface_dps310.c
+++ b/src/interfaces/environmental/ruuvi_interface_dps310.c
@@ -133,6 +133,10 @@ rd_status_t ri_dps310_samplerate_set (uint8_t * samplerate)
     {
         err_code |= RD_ERROR_NULL;
     }
+    else if (DPS310_READY != singleton_ctx_spi.device_status)
+    {
+        err_code |= RD_ERROR_INVALID_STATE;
+    }
     else if (RD_SENSOR_CFG_NO_CHANGE == *samplerate)
     {
         // No action needed.
@@ -320,22 +324,100 @@ rd_status_t ri_dps310_samplerate_get (uint8_t * samplerate)
 
 rd_status_t ri_dps310_resolution_set (uint8_t * resolution)
 {
-    return RD_ERROR_NOT_IMPLEMENTED;
+    rd_status_t err_code = RD_SUCCESS;
+    dps310_status_t dps_status = DPS310_SUCCESS;
+
+    if (NULL == resolution)
+    {
+        err_code |= RD_ERROR_NULL;
+    }
+    else if (DPS310_READY != singleton_ctx_spi.device_status)
+    {
+        err_code |= RD_ERROR_INVALID_STATE;
+    }
+    else if ( (RD_SENSOR_CFG_DEFAULT == *resolution)
+              || (RD_SENSOR_CFG_MIN == *resolution)
+              || (RD_SENSOR_CFG_MAX == *resolution)
+              || (RD_SENSOR_CFG_NO_CHANGE == *resolution))
+    {
+        *resolution = RD_SENSOR_CFG_DEFAULT;
+    }
+    else
+    {
+        err_code |= RD_ERROR_NOT_SUPPORTED;
+    }
+
+    return err_code;
 }
 
 rd_status_t ri_dps310_resolution_get (uint8_t * resolution)
 {
-    return RD_ERROR_NOT_IMPLEMENTED;
+    rd_status_t err_code = RD_SUCCESS;
+    dps310_status_t dps_status = DPS310_SUCCESS;
+
+    if (NULL == resolution)
+    {
+        err_code |= RD_ERROR_NULL;
+    }
+    else if (DPS310_READY != singleton_ctx_spi.device_status)
+    {
+        err_code |= RD_ERROR_INVALID_STATE;
+    }
+    else
+    {
+        *resolution = RD_SENSOR_CFG_DEFAULT;
+    }
+
+    return err_code;
 }
 
 rd_status_t ri_dps310_scale_set (uint8_t * scale)
 {
-    return RD_ERROR_NOT_IMPLEMENTED;
+    rd_status_t err_code = RD_SUCCESS;
+    dps310_status_t dps_status = DPS310_SUCCESS;
+
+    if (NULL == scale)
+    {
+        err_code |= RD_ERROR_NULL;
+    }
+    else if (DPS310_READY != singleton_ctx_spi.device_status)
+    {
+        err_code |= RD_ERROR_INVALID_STATE;
+    }
+    else if ( (RD_SENSOR_CFG_DEFAULT == *scale)
+              || (RD_SENSOR_CFG_MIN == *scale)
+              || (RD_SENSOR_CFG_MAX == *scale)
+              || (RD_SENSOR_CFG_NO_CHANGE == *scale))
+    {
+        *scale = RD_SENSOR_CFG_DEFAULT;
+    }
+    else
+    {
+        err_code |= RD_ERROR_NOT_SUPPORTED;
+    }
+
+    return err_code;
 }
 
 rd_status_t ri_dps310_scale_get (uint8_t * scale)
 {
-    return RD_ERROR_NOT_IMPLEMENTED;
+    rd_status_t err_code = RD_SUCCESS;
+    dps310_status_t dps_status = DPS310_SUCCESS;
+
+    if (NULL == scale)
+    {
+        err_code |= RD_ERROR_NULL;
+    }
+    else if (DPS310_READY != singleton_ctx_spi.device_status)
+    {
+        err_code |= RD_ERROR_INVALID_STATE;
+    }
+    else
+    {
+        *scale = RD_SENSOR_CFG_DEFAULT;
+    }
+
+    return err_code;
 }
 
 rd_status_t ri_dps310_dsp_set (uint8_t * dsp, uint8_t * parameter)

--- a/src/interfaces/environmental/ruuvi_interface_dps310.c
+++ b/src/interfaces/environmental/ruuvi_interface_dps310.c
@@ -88,17 +88,20 @@ rd_status_t ri_dps310_init (rd_sensor_t * p_sensor, rd_bus_t bus, uint8_t handle
             }
         }
 
-        dps_status = dps310_init (p_sensor->p_ctx);
+        if (RD_SUCCESS == err_code)
+        {
+            dps_status = dps310_init (p_sensor->p_ctx);
 
-        if (DPS310_SUCCESS == dps_status)
-        {
-            rd_sensor_initialize (p_sensor);
-            dps310_fp_setup (p_sensor);
-            p_sensor->name = name;
-        }
-        else
-        {
-            err_code |= RD_ERROR_NOT_FOUND;
+            if (DPS310_SUCCESS == dps_status)
+            {
+                rd_sensor_initialize (p_sensor);
+                dps310_fp_setup (p_sensor);
+                p_sensor->name = name;
+            }
+            else
+            {
+                err_code |= RD_ERROR_NOT_FOUND;
+            }
         }
     }
 
@@ -235,13 +238,17 @@ rd_status_t ri_dps310_samplerate_set (uint8_t * samplerate)
         err_code |= RD_ERROR_NOT_SUPPORTED;
     }
 
-    if (DPS310_SUCCESS == dps_status)
+    if ( (DPS310_SUCCESS == dps_status) && (RD_SUCCESS == err_code))
     {
         err_code |= ri_dps310_samplerate_get (samplerate);
     }
-    else
+    else if (RD_SUCCESS == err_code)
     {
         err_code |= RD_ERROR_INTERNAL;
+    }
+    else
+    {
+        // No action needed.
     }
 
     return err_code;

--- a/src/interfaces/environmental/ruuvi_interface_dps310.h
+++ b/src/interfaces/environmental/ruuvi_interface_dps310.h
@@ -1,0 +1,76 @@
+#ifndef RUUVI_INTERFACE_DPS310_H
+#define RUUVI_INTERFACE_DPS310_H
+#include "ruuvi_driver_error.h"
+#include "ruuvi_driver_sensor.h"
+
+/**
+ * @addtogroup Environmental
+ */
+/** @{ */
+/**
+ * @defgroup DPS310 DPS310 Inteface
+ * @brief Implement @ref rd_sensor_t functions on DPS310
+ *
+ * The implementation supports
+ * different samplerates and oversampling.
+ */
+/** @} */
+/**
+ * @addtogroup DPS310
+ */
+/** @{ */
+/**
+ * @file ruuvi_interface_dps310.h
+ * @author Otso Jousimaa <otso@ojousima.net>
+ * @date 2020-12-28
+ * @copyright Ruuvi Innovations Ltd, license BSD-3-Clause.
+ *
+ * Interface for DPS310 basic usage. The underlying platform must provide
+ * functions for SPI and/or I2C access, @ref ruuvi_interface_spi_dps310.h and
+ * @ref ruuvi_interface_i2c_dps310.h.
+ *
+ * Testing the interface with @ref test_sensor.h
+ *
+ * @code{.c}
+ *  rd_status_t err_code = RD_SUCCESS;
+ *  rd_bus_t bus = RD_BUS_NONE;
+ *  uint8_t handle = 0;
+ *  rd_sensor_init_fp init = ri_dps310_init;
+ *  bus = RD_BUS_SPI;
+ *  handle = RUUVI_BOARD_SPI_SS_ENVIRONMENTAL_PIN;
+ *  err_code = test_sensor_init(init, bus, handle);
+ *  err_code = test_sensor_setup(init, bus, handle);
+ *  err_code = test_sensor_modes(init, bus, handle);
+ *  RD_ERROR_CHECK(err_code, RD_ERROR_SELFTEST);
+ * @endcode
+ */
+
+/** @brief @ref rd_sensor_init_fp */
+rd_status_t ri_dps310_init (rd_sensor_t * p_sensor, rd_bus_t bus, uint8_t handle);
+/** @brief @ref rd_sensor_init_fp */
+rd_status_t ri_dps310_uninit (rd_sensor_t * p_sensor, rd_bus_t bus, uint8_t handle);
+/** @brief @ref rd_sensor_setup_fp */
+rd_status_t ri_dps310_samplerate_set (uint8_t * samplerate);
+/** @brief @ref rd_sensor_setup_fp */
+rd_status_t ri_dps310_samplerate_get (uint8_t * samplerate);
+/** @brief @ref rd_sensor_setup_fp */
+rd_status_t ri_dps310_resolution_set (uint8_t * resolution);
+/** @brief @ref rd_sensor_setup_fp */
+rd_status_t ri_dps310_resolution_get (uint8_t * resolution);
+/** @brief @ref rd_sensor_setup_fp */
+rd_status_t ri_dps310_scale_set (uint8_t * scale);
+/** @brief @ref rd_sensor_setup_fp */
+rd_status_t ri_dps310_scale_get (uint8_t * scale);
+/** @brief @ref rd_sensor_dsp_fp */
+rd_status_t ri_dps310_dsp_set (uint8_t * dsp, uint8_t * parameter);
+/** @brief @ref rd_sensor_dsp_fp */
+rd_status_t ri_dps310_dsp_get (uint8_t * dsp, uint8_t * parameter);
+/** @brief @ref rd_sensor_setup_fp */
+rd_status_t ri_dps310_mode_set (uint8_t * mode);
+/** @brief @ref rd_sensor_setup_fp */
+rd_status_t ri_dps310_mode_get (uint8_t * mode);
+/** @brief @ref rd_sensor_data_fp */
+rd_status_t ri_dps310_data_get (rd_sensor_data_t * const data);
+
+/** @} */
+#endif // RUUVI_INTERFACE_DPS310_H

--- a/src/interfaces/spi/ruuvi_interface_spi_dps310.c
+++ b/src/interfaces/spi/ruuvi_interface_spi_dps310.c
@@ -1,0 +1,14 @@
+#include "ruuvi_interface_spi_dps310.h"
+#include <stdint.h>
+
+uint32_t ri_spi_dps310_write (uint8_t dev_id, uint8_t reg_addr,
+                              uint8_t * p_reg_data, uint16_t len)
+{
+    return 0;
+}
+
+uint32_t ri_spi_dps310_read (uint8_t dev_id, uint8_t reg_addr,
+                             uint8_t * reg_data, uint16_t len)
+{
+    return 0;
+}

--- a/src/interfaces/spi/ruuvi_interface_spi_dps310.c
+++ b/src/interfaces/spi/ruuvi_interface_spi_dps310.c
@@ -1,14 +1,32 @@
 #include "ruuvi_interface_spi_dps310.h"
+#include "ruuvi_driver_error.h"
+#include "ruuvi_driver_sensor.h"
+#include "ruuvi_interface_gpio.h"
+#include "ruuvi_interface_spi.h"
 #include <stdint.h>
 
 uint32_t ri_spi_dps310_write (const void * const comm_ctx, const uint8_t reg_addr,
                               const uint8_t * const data, const uint8_t data_len)
 {
-    return 0;
+    rd_status_t err_code = RD_SUCCESS;
+    ri_gpio_id_t ss = * (ri_gpio_id_t *) comm_ctx;
+    ss = RD_HANDLE_TO_GPIO (ss);
+    err_code |= ri_gpio_write (ss, RI_GPIO_LOW);
+    err_code |= ri_spi_xfer_blocking (&reg_addr, 1, NULL, 0);
+    err_code |= ri_spi_xfer_blocking (data, data_len, NULL, 0);
+    err_code |= ri_gpio_write (ss, RI_GPIO_HIGH);
+    return err_code;
 }
 
 uint32_t ri_spi_dps310_read (const void * const comm_ctx, const uint8_t reg_addr,
                              uint8_t * const data, const uint8_t data_len)
 {
-    return 0;
+    rd_status_t err_code = RD_SUCCESS;
+    ri_gpio_id_t ss = * (ri_gpio_id_t *) comm_ctx;
+    ss = RD_HANDLE_TO_GPIO (ss);
+    err_code |= ri_gpio_write (ss, RI_GPIO_LOW);
+    err_code |= ri_spi_xfer_blocking (&reg_addr, 1, NULL, 0);
+    err_code |= ri_spi_xfer_blocking (NULL, 0, data, data_len);
+    err_code |= ri_gpio_write (ss, RI_GPIO_HIGH);
+    return err_code;
 }

--- a/src/interfaces/spi/ruuvi_interface_spi_dps310.c
+++ b/src/interfaces/spi/ruuvi_interface_spi_dps310.c
@@ -1,14 +1,14 @@
 #include "ruuvi_interface_spi_dps310.h"
 #include <stdint.h>
 
-uint32_t ri_spi_dps310_write (uint8_t dev_id, uint8_t reg_addr,
-                              uint8_t * p_reg_data, uint16_t len)
+uint32_t ri_spi_dps310_write (const void * const comm_ctx, const uint8_t reg_addr,
+                              const uint8_t * const data, const uint8_t data_len)
 {
     return 0;
 }
 
-uint32_t ri_spi_dps310_read (uint8_t dev_id, uint8_t reg_addr,
-                             uint8_t * reg_data, uint16_t len)
+uint32_t ri_spi_dps310_read (const void * const comm_ctx, const uint8_t reg_addr,
+                             uint8_t * const data, const uint8_t data_len)
 {
     return 0;
 }

--- a/src/interfaces/spi/ruuvi_interface_spi_dps310.c
+++ b/src/interfaces/spi/ruuvi_interface_spi_dps310.c
@@ -1,9 +1,12 @@
+#include "ruuvi_driver_enabled_modules.h"
 #include "ruuvi_interface_spi_dps310.h"
 #include "ruuvi_driver_error.h"
 #include "ruuvi_driver_sensor.h"
 #include "ruuvi_interface_gpio.h"
 #include "ruuvi_interface_spi.h"
 #include <stdint.h>
+
+#if RI_DPS310_SPI_ENABLED
 
 uint32_t ri_spi_dps310_write (const void * const comm_ctx, const uint8_t reg_addr,
                               const uint8_t * const data, const uint8_t data_len)
@@ -30,3 +33,5 @@ uint32_t ri_spi_dps310_read (const void * const comm_ctx, const uint8_t reg_addr
     err_code |= ri_gpio_write (ss, RI_GPIO_HIGH);
     return err_code;
 }
+
+#endif

--- a/src/interfaces/spi/ruuvi_interface_spi_dps310.h
+++ b/src/interfaces/spi/ruuvi_interface_spi_dps310.h
@@ -17,16 +17,6 @@
  * The wrappers will use Ruuvi Interface internally, so you don't have to port these to
  * use DPS310 on a new platform. You're required to port @ref Yield, @ref GPIO and @ref SPI.
  *
- * General usage is:
- * @code{c}
- * static struct bme280_dev dev = {0};
- * dev.dev_id = bme280_cs_pin;
- * dev.intf = BME280_SPI_INTF;
- * dev.read = ri_spi_bme280_read;
- * dev.write = ri_spi_bme280_write;
- * dev.delay_ms = bosch_delay_ms;
- * bme280_init(&dev);
- * @endcode
  */
 
 /**
@@ -39,6 +29,9 @@
  * @param[in] reg_addr DPS310 register address to write.
  * @param[in] p_reg_data pointer to data to be written.
  * @param[in] len length of data to be written.
+ *
+ * @retval 0 on Success.
+ * @return Error code from SPI implementation on error.
  **/
 uint32_t ri_spi_dps310_write (const void * const comm_ctx, const uint8_t reg_addr,
                               const uint8_t * const data, const uint8_t data_len);
@@ -53,6 +46,8 @@ uint32_t ri_spi_dps310_write (const void * const comm_ctx, const uint8_t reg_add
  * @param[in] reg_addr DPS310 register address to read.
  * @param[in] p_reg_data pointer to data to be received.
  * @param[in] len length of data to be received.
+ * @retval 0 on Success.
+ * @return Error code from SPI implementation on error.
  **/
 uint32_t ri_spi_dps310_read (const void * const comm_ctx, const uint8_t reg_addr,
                              uint8_t * const data, const uint8_t data_len);

--- a/src/interfaces/spi/ruuvi_interface_spi_dps310.h
+++ b/src/interfaces/spi/ruuvi_interface_spi_dps310.h
@@ -1,0 +1,61 @@
+#ifndef RUUVI_INTERFACE_SPI_DPS310_H
+#define RUUVI_INTERFACE_SPI_DPS310_H
+#include <stdint.h>
+/**
+ * @addtogroup SPI
+ * @{
+ */
+/**
+ * @file ruuvi_interface_spi_dps310.h
+ * @author Otso Jousimaa <otso@ojousima.net>
+ * @brief SPI read/write functions for Infineon DPS310.
+ * @date 2020-12-31
+ * @copyright Ruuvi Innovations Ltd, license BSD-3-Clause.
+ *
+ * You'll need to get the Ruuvi's DPS310, available at
+ * <a href="https://github.com/BoschSensortec/BME280_driver">GitHub</a>.
+ * The wrappers will use Ruuvi Interface internally, so you don't have to port these to
+ * use DPS310 on a new platform. You're required to port @ref Yield, @ref GPIO and @ref SPI.
+ *
+ * General usage is:
+ * @code{c}
+ * static struct bme280_dev dev = {0};
+ * dev.dev_id = bme280_cs_pin;
+ * dev.intf = BME280_SPI_INTF;
+ * dev.read = ri_spi_bme280_read;
+ * dev.write = ri_spi_bme280_write;
+ * dev.delay_ms = bosch_delay_ms;
+ * bme280_init(&dev);
+ * @endcode
+ */
+
+/**
+ * @brief SPI write function for DPS310
+ *
+ * Binds Ruuvi Interface SPI functions into Ruuvi's DPS310 driver.
+ * Handles GPIO chip select, there is no forced delay to let the CS settle.
+ *
+ * @param[in] dev_id @ref SPI interface handle, i.e. pin number of the chip select pin of DPS310.
+ * @param[in] reg_addr DPS310 register address to write.
+ * @param[in] p_reg_data pointer to data to be written.
+ * @param[in] len length of data to be written.
+ **/
+uint32_t ri_spi_dps310_write (uint8_t dev_id, uint8_t reg_addr,
+                              uint8_t * p_reg_data, uint16_t len);
+
+/**
+ * @brief SPI Read function for DPS310
+ *
+ * Binds Ruuvi Interface SPI functions into Ruuvi DPS310 driver.
+ * Handles GPIO chip select, there is no forced delay to let the CS settle.
+ *
+ * @param[in] dev_id @ref SPI interface handle, i.e. pin number of the chip select pin of DPS310.
+ * @param[in] reg_addr DPS310 register address to read.
+ * @param[in] p_reg_data pointer to data to be received.
+ * @param[in] len length of data to be received.
+ **/
+uint32_t ri_spi_dps310_read (uint8_t dev_id, uint8_t reg_addr,
+                             uint8_t * reg_data, uint16_t len);
+/** @} */
+
+#endif // RUUVI_INTERFACE_SPI_DPS310_H

--- a/src/interfaces/spi/ruuvi_interface_spi_dps310.h
+++ b/src/interfaces/spi/ruuvi_interface_spi_dps310.h
@@ -40,8 +40,8 @@
  * @param[in] p_reg_data pointer to data to be written.
  * @param[in] len length of data to be written.
  **/
-uint32_t ri_spi_dps310_write (uint8_t dev_id, uint8_t reg_addr,
-                              uint8_t * p_reg_data, uint16_t len);
+uint32_t ri_spi_dps310_write (const void * const comm_ctx, const uint8_t reg_addr,
+                              const uint8_t * const data, const uint8_t data_len);
 
 /**
  * @brief SPI Read function for DPS310
@@ -54,8 +54,8 @@ uint32_t ri_spi_dps310_write (uint8_t dev_id, uint8_t reg_addr,
  * @param[in] p_reg_data pointer to data to be received.
  * @param[in] len length of data to be received.
  **/
-uint32_t ri_spi_dps310_read (uint8_t dev_id, uint8_t reg_addr,
-                             uint8_t * reg_data, uint16_t len);
+uint32_t ri_spi_dps310_read (const void * const comm_ctx, const uint8_t reg_addr,
+                             uint8_t * const data, const uint8_t data_len);
 /** @} */
 
 #endif // RUUVI_INTERFACE_SPI_DPS310_H

--- a/src/ruuvi_driver_enabled_modules.h
+++ b/src/ruuvi_driver_enabled_modules.h
@@ -18,7 +18,7 @@
 #define RUUVI_DRIVER_ENABLED_MODULES_H
 
 /** @brief SemVer string, must match latest tag. */
-#define RUUVI_DRIVERS_SEMVER "3.4.5"
+#define RUUVI_DRIVERS_SEMVER "3.5.0"
 
 #ifdef CEEDLING
 #  define ENABLE_DEFAULT 1
@@ -231,6 +231,16 @@ data payload length is the maximum length */
 #   endif
 #   ifndef RI_BME280_I2C_ENABLED
 #       define RI_BME280_I2C_ENABLED ENABLE_DEFAULT
+#   endif
+#endif
+
+#ifndef RI_DPS310_ENABLED
+#   define RI_DPS310_ENABLED ENABLE_DEFAULT
+#   ifndef RI_DPS310_SPI_ENABLED
+#       define RI_DPS310_SPI_ENABLED ENABLE_DEFAULT
+#   endif
+#   ifndef RI_DPS310_I2C_ENABLED
+#       define RI_DPS310_I2C_ENABLED ENABLE_DEFAULT
 #   endif
 #endif
 

--- a/src/ruuvi_driver_sensor.h
+++ b/src/ruuvi_driver_sensor.h
@@ -362,14 +362,16 @@ typedef uint64_t (*rd_sensor_timestamp_fp) (void);
  */
 typedef struct rd_sensor_t
 {
-    /** @brief sensor human-readable name. Should be at most 8 bytes long. */
+    /** @brief Sensor human-readable name. Should be at most 8 bytes long. */
     const char * name;
+    /** @brief handle for sensor internal context */
+    void * p_ctx;
     /** @brief Description of data fields the sensor is able to provide. */
     rd_sensor_data_fields_t provides;
     /** @brief @ref rd_sensor_init_fp */
-    rd_sensor_init_fp   init;
+    rd_sensor_init_fp  init;
     /** @brief @ref rd_sensor_init_fp */
-    rd_sensor_init_fp   uninit;
+    rd_sensor_init_fp  uninit;
     /** @brief @ref rd_sensor_setup_fp */
     rd_sensor_setup_fp samplerate_set;
     /** @brief @ref rd_sensor_setup_fp */

--- a/src/ruuvi_driver_sensor.h
+++ b/src/ruuvi_driver_sensor.h
@@ -267,12 +267,14 @@ typedef rd_status_t (*rd_sensor_dsp_fp) (uint8_t * dsp_function,
  * in a row returns same data. Configure sensor in a single-shot mode to take a new sample
  * or leave sensor in a continuous mode to get updated data.
  *
+ * p_data may contain, some, none or all of fields sensor is able to provide.
+ * Fields which are already marked as valid will not be overwritten, filled fields
+ * will get marked as valid.
+ *
  * @param [out] p_data Pointer to sensor data @ref rd_sensor_data_t .
  * @return RD_SUCCESS on success
  * @return RD_ERROR_NULL if p_data is @c NULL.
  *
- * @warning if sensor data is not valid for any reason, data is populated with
- *          @c RD_FLOAT_INVALID.
  */
 typedef rd_status_t (*rd_sensor_data_fp) (rd_sensor_data_t * const p_data);
 

--- a/test/interfaces/environmental/test_ruuvi_interface_dps310.c
+++ b/test/interfaces/environmental/test_ruuvi_interface_dps310.c
@@ -123,6 +123,7 @@ void test_ri_dps310_samplerate_set_ok (void)
     test_ri_dps310_init_singleton();
     // Take address of singleton context to simulate state updates in driver
     dps310_ctx_t * const p_ctx = (dps310_ctx_t *) dps_ctx.p_ctx;
+    p_ctx->device_status = DPS310_READY;
 
     for (uint8_t rate = 0U; rate < 129U; rate ++)
     {
@@ -288,18 +289,108 @@ void test_ri_dps310_samplerate_set_ok (void)
         }
     }
 }
-/** @brief @ref rd_sensor_setup_fp */
-rd_status_t ri_dps310_samplerate_get (uint8_t * samplerate);
+
+// sanplerate_get is tested through set, not need to test separately.
+
+void test_ri_dps310_resolution_set_default (void)
+{
+    rd_status_t err_code = RD_SUCCESS;
+    // Run singleton test to initialize sensor context.
+    test_ri_dps310_init_singleton();
+    dps310_ctx_t * const p_ctx = (dps310_ctx_t *) dps_ctx.p_ctx;
+    p_ctx->device_status = DPS310_READY;
+    uint8_t resolution = RD_SENSOR_CFG_DEFAULT;
+    ri_dps310_resolution_set (&resolution);
+    TEST_ASSERT (RD_SENSOR_CFG_DEFAULT == resolution);
+}
+
+void test_ri_dps310_resolution_set_min (void)
+{
+    rd_status_t err_code = RD_SUCCESS;
+    // Run singleton test to initialize sensor context.
+    test_ri_dps310_init_singleton();
+    dps310_ctx_t * const p_ctx = (dps310_ctx_t *) dps_ctx.p_ctx;
+    p_ctx->device_status = DPS310_READY;
+    uint8_t resolution = RD_SENSOR_CFG_MIN;
+    ri_dps310_resolution_set (&resolution);
+    TEST_ASSERT (RD_SENSOR_CFG_DEFAULT == resolution);
+}
+
+void test_ri_dps310_resolution_set_max (void)
+{
+    rd_status_t err_code = RD_SUCCESS;
+    // Run singleton test to initialize sensor context.
+    test_ri_dps310_init_singleton();
+    dps310_ctx_t * const p_ctx = (dps310_ctx_t *) dps_ctx.p_ctx;
+    p_ctx->device_status = DPS310_READY;
+    uint8_t resolution = RD_SENSOR_CFG_MAX;
+    ri_dps310_resolution_set (&resolution);
+    TEST_ASSERT (RD_SENSOR_CFG_DEFAULT == resolution);
+}
+
+void test_ri_dps310_resolution_set_no_change (void)
+{
+    rd_status_t err_code = RD_SUCCESS;
+    // Run singleton test to initialize sensor context.
+    test_ri_dps310_init_singleton();
+    dps310_ctx_t * const p_ctx = (dps310_ctx_t *) dps_ctx.p_ctx;
+    p_ctx->device_status = DPS310_READY;
+    uint8_t resolution = RD_SENSOR_CFG_NO_CHANGE;
+    ri_dps310_resolution_set (&resolution);
+    TEST_ASSERT (RD_SENSOR_CFG_DEFAULT == resolution);
+}
+
+// resolution get gets tested by resolution set.
+
+void test_ri_dps310_scale_set_default (void)
+{
+    rd_status_t err_code = RD_SUCCESS;
+    // Run singleton test to initialize sensor context.
+    test_ri_dps310_init_singleton();
+    dps310_ctx_t * const p_ctx = (dps310_ctx_t *) dps_ctx.p_ctx;
+    p_ctx->device_status = DPS310_READY;
+    uint8_t scale = RD_SENSOR_CFG_DEFAULT;
+    ri_dps310_scale_set (&scale);
+    TEST_ASSERT (RD_SENSOR_CFG_DEFAULT == scale);
+}
+
+void test_ri_dps310_scale_set_min (void)
+{
+    rd_status_t err_code = RD_SUCCESS;
+    // Run singleton test to initialize sensor context.
+    test_ri_dps310_init_singleton();
+    dps310_ctx_t * const p_ctx = (dps310_ctx_t *) dps_ctx.p_ctx;
+    p_ctx->device_status = DPS310_READY;
+    uint8_t scale = RD_SENSOR_CFG_MIN;
+    ri_dps310_scale_set (&scale);
+    TEST_ASSERT (RD_SENSOR_CFG_DEFAULT == scale);
+}
+
+void test_ri_dps310_scale_set_max (void)
+{
+    rd_status_t err_code = RD_SUCCESS;
+    // Run singleton test to initialize sensor context.
+    test_ri_dps310_init_singleton();
+    dps310_ctx_t * const p_ctx = (dps310_ctx_t *) dps_ctx.p_ctx;
+    p_ctx->device_status = DPS310_READY;
+    uint8_t scale = RD_SENSOR_CFG_MAX;
+    ri_dps310_scale_set (&scale);
+    TEST_ASSERT (RD_SENSOR_CFG_DEFAULT == scale);
+}
+
+void test_ri_dps310_scale_set_no_change (void)
+{
+    rd_status_t err_code = RD_SUCCESS;
+    // Run singleton test to initialize sensor context.
+    test_ri_dps310_init_singleton();
+    dps310_ctx_t * const p_ctx = (dps310_ctx_t *) dps_ctx.p_ctx;
+    p_ctx->device_status = DPS310_READY;
+    uint8_t scale = RD_SENSOR_CFG_NO_CHANGE;
+    ri_dps310_scale_set (&scale);
+    TEST_ASSERT (RD_SENSOR_CFG_DEFAULT == scale);
+}
 
 #if 0
-/** @brief @ref rd_sensor_setup_fp */
-rd_status_t ri_dps310_resolution_set (uint8_t * resolution);
-/** @brief @ref rd_sensor_setup_fp */
-rd_status_t ri_dps310_resolution_get (uint8_t * resolution);
-/** @brief @ref rd_sensor_setup_fp */
-rd_status_t ri_dps310_scale_set (uint8_t * scale);
-/** @brief @ref rd_sensor_setup_fp */
-rd_status_t ri_dps310_scale_get (uint8_t * scale);
 /** @brief @ref rd_sensor_dsp_fp */
 rd_status_t ri_dps310_dsp_set (uint8_t * dsp, uint8_t * parameter);
 /** @brief @ref rd_sensor_dsp_fp */

--- a/test/interfaces/environmental/test_ruuvi_interface_dps310.c
+++ b/test/interfaces/environmental/test_ruuvi_interface_dps310.c
@@ -653,6 +653,10 @@ void test_ri_dps310_mode_set_continuous_ok (void)
     dps310_measure_continuous_async_ExpectAndReturn (p_ctx, DPS310_SUCCESS);
     err_code = ri_dps310_mode_set (&mode);
     TEST_ASSERT (RD_SUCCESS == err_code);
+    // Use a separate call to mode_get to simulate mode_set changing DPS internal state-
+    p_ctx->device_status = DPS310_CONTINUOUS;
+    err_code = ri_dps310_mode_get (&mode);
+    TEST_ASSERT (RD_SENSOR_CFG_CONTINUOUS == mode);
 }
 
 rd_status_t ri_dps310_mode_set (uint8_t * mode);

--- a/test/interfaces/environmental/test_ruuvi_interface_dps310.c
+++ b/test/interfaces/environmental/test_ruuvi_interface_dps310.c
@@ -10,12 +10,17 @@
 
 #include "string.h"
 
+static void dummy_sleep (const uint32_t ms)
+{
+    // No action needed.
+}
+
 rd_sensor_t dps_ctx;
 dps310_ctx_t init_ctx =
 {
     .write = &ri_spi_dps310_write,
     .read  = &ri_spi_dps310_read,
-    .sleep = &ri_delay_ms
+    .sleep = &dummy_sleep
 };
 
 void setUp (void)
@@ -52,16 +57,66 @@ void test_ri_dps310_init_ok (void)
     TEST_ASSERT (&ri_dps310_data_get == dps_ctx.data_get);
 }
 
+void test_ri_dps310_init_singleton (void)
+{
+    rd_sensor_is_init_ExpectAndReturn (&dps_ctx, false);
+    dps310_init_ExpectAndReturn (NULL, DPS310_SUCCESS);
+    dps310_init_IgnoreArg_ctx();
+    rd_sensor_initialize_Expect (&dps_ctx);
+    rd_status_t err_code = ri_dps310_init (&dps_ctx, RD_BUS_SPI, 1U);
+    TEST_ASSERT (RD_SUCCESS == err_code);
+    TEST_ASSERT (&ri_dps310_init == dps_ctx.init);
+    TEST_ASSERT (&ri_dps310_uninit == dps_ctx.uninit);
+    TEST_ASSERT (&ri_dps310_samplerate_set == dps_ctx.samplerate_set);
+    TEST_ASSERT (&ri_dps310_samplerate_get == dps_ctx.samplerate_get);
+    TEST_ASSERT (&ri_dps310_resolution_set == dps_ctx.resolution_set);
+    TEST_ASSERT (&ri_dps310_resolution_get == dps_ctx.resolution_get);
+    TEST_ASSERT (&ri_dps310_scale_set == dps_ctx.scale_set);
+    TEST_ASSERT (&ri_dps310_scale_get == dps_ctx.scale_get);
+    TEST_ASSERT (&ri_dps310_mode_set == dps_ctx.mode_set);
+    TEST_ASSERT (&ri_dps310_mode_get == dps_ctx.mode_get);
+    TEST_ASSERT (&ri_dps310_dsp_set == dps_ctx.dsp_set);
+    TEST_ASSERT (&ri_dps310_dsp_get == dps_ctx.dsp_get);
+    TEST_ASSERT (&ri_dps310_data_get == dps_ctx.data_get);
+    TEST_ASSERT (NULL != dps_ctx.p_ctx);
+    dps310_ctx_t * p_dps_ctx = (dps310_ctx_t *) dps_ctx.p_ctx;
+    TEST_ASSERT (NULL != p_dps_ctx->comm_ctx);
+    uint8_t * comm_ctx = (uint8_t *) p_dps_ctx->comm_ctx;
+    TEST_ASSERT (1U == *comm_ctx);
+}
+
+
 void test_ri_dps310_init_null (void)
 {
     rd_status_t err_code = ri_dps310_init (NULL, RD_BUS_SPI, 0);
     TEST_ASSERT (RD_ERROR_NULL == err_code);
 }
 
+
+void test_ri_dps310_init_twice (void)
+{
+    dps_ctx.p_ctx = &init_ctx;
+    rd_sensor_is_init_ExpectAndReturn (&dps_ctx, true);
+    rd_status_t err_code = ri_dps310_init (&dps_ctx, RD_BUS_SPI, 1U);
+    TEST_ASSERT (RD_ERROR_INVALID_STATE == err_code);
+}
+
+void test_ri_dps310_uninit_ok (void)
+{
+    dps_ctx.p_ctx = &init_ctx;
+    dps310_uninit_ExpectAndReturn (&init_ctx, DPS310_SUCCESS);
+    rd_status_t err_code = ri_dps310_uninit (&dps_ctx, RD_BUS_SPI, 1U);
+    TEST_ASSERT (RD_SUCCESS == err_code);
+}
+
+void test_ri_dps310_uninit_null (void)
+{
+    dps_ctx.p_ctx = &init_ctx;
+    rd_status_t err_code = ri_dps310_uninit (NULL, RD_BUS_SPI, 1U);
+    TEST_ASSERT (RD_ERROR_NULL == err_code);
+}
+
 #if 0
-/** @brief @ref rd_sensor_init_fp */
-rd_status_t ri_dps310_uninit (rd_sensor_t *
-                              environmental_sensor, rd_bus_t bus, uint8_t handle);
 /** @brief @ref rd_sensor_setup_fp */
 rd_status_t ri_dps310_samplerate_set (uint8_t * samplerate);
 /** @brief @ref rd_sensor_setup_fp */

--- a/test/interfaces/environmental/test_ruuvi_interface_dps310.c
+++ b/test/interfaces/environmental/test_ruuvi_interface_dps310.c
@@ -1,0 +1,87 @@
+#include "unity.h"
+
+#include "mock_dps310.h"
+#include "mock_ruuvi_driver_error.h"
+#include "mock_ruuvi_driver_sensor.h"
+#include "mock_ruuvi_interface_log.h"
+#include "mock_ruuvi_interface_spi_dps310.h"
+#include "mock_ruuvi_interface_yield.h"
+#include "ruuvi_interface_dps310.h"
+
+#include "string.h"
+
+rd_sensor_t dps_ctx;
+dps310_ctx_t init_ctx =
+{
+    .write = &ri_spi_dps310_write,
+    .read  = &ri_spi_dps310_read,
+    .sleep = &ri_delay_ms
+};
+
+void setUp (void)
+{
+    memset (&dps_ctx, 0, sizeof (dps_ctx));
+    ri_log_Ignore();
+}
+
+void tearDown (void)
+{
+}
+
+/** @brief @ref rd_sensor_init_fp */
+void test_ri_dps310_init_ok (void)
+{
+    dps_ctx.p_ctx = &init_ctx;
+    rd_sensor_is_init_ExpectAndReturn (&dps_ctx, false);
+    dps310_init_ExpectAndReturn (&init_ctx, DPS310_SUCCESS);
+    rd_sensor_initialize_Expect (&dps_ctx);
+    rd_status_t err_code = ri_dps310_init (&dps_ctx, RD_BUS_SPI, 1U);
+    TEST_ASSERT (RD_SUCCESS == err_code);
+    TEST_ASSERT (&ri_dps310_init == dps_ctx.init);
+    TEST_ASSERT (&ri_dps310_uninit == dps_ctx.uninit);
+    TEST_ASSERT (&ri_dps310_samplerate_set == dps_ctx.samplerate_set);
+    TEST_ASSERT (&ri_dps310_samplerate_get == dps_ctx.samplerate_get);
+    TEST_ASSERT (&ri_dps310_resolution_set == dps_ctx.resolution_set);
+    TEST_ASSERT (&ri_dps310_resolution_get == dps_ctx.resolution_get);
+    TEST_ASSERT (&ri_dps310_scale_set == dps_ctx.scale_set);
+    TEST_ASSERT (&ri_dps310_scale_get == dps_ctx.scale_get);
+    TEST_ASSERT (&ri_dps310_mode_set == dps_ctx.mode_set);
+    TEST_ASSERT (&ri_dps310_mode_get == dps_ctx.mode_get);
+    TEST_ASSERT (&ri_dps310_dsp_set == dps_ctx.dsp_set);
+    TEST_ASSERT (&ri_dps310_dsp_get == dps_ctx.dsp_get);
+    TEST_ASSERT (&ri_dps310_data_get == dps_ctx.data_get);
+}
+
+void test_ri_dps310_init_null (void)
+{
+    rd_status_t err_code = ri_dps310_init (NULL, RD_BUS_SPI, 0);
+    TEST_ASSERT (RD_ERROR_NULL == err_code);
+}
+
+#if 0
+/** @brief @ref rd_sensor_init_fp */
+rd_status_t ri_dps310_uninit (rd_sensor_t *
+                              environmental_sensor, rd_bus_t bus, uint8_t handle);
+/** @brief @ref rd_sensor_setup_fp */
+rd_status_t ri_dps310_samplerate_set (uint8_t * samplerate);
+/** @brief @ref rd_sensor_setup_fp */
+rd_status_t ri_dps310_samplerate_get (uint8_t * samplerate);
+/** @brief @ref rd_sensor_setup_fp */
+rd_status_t ri_dps310_resolution_set (uint8_t * resolution);
+/** @brief @ref rd_sensor_setup_fp */
+rd_status_t ri_dps310_resolution_get (uint8_t * resolution);
+/** @brief @ref rd_sensor_setup_fp */
+rd_status_t ri_dps310_scale_set (uint8_t * scale);
+/** @brief @ref rd_sensor_setup_fp */
+rd_status_t ri_dps310_scale_get (uint8_t * scale);
+/** @brief @ref rd_sensor_dsp_fp */
+rd_status_t ri_dps310_dsp_set (uint8_t * dsp, uint8_t * parameter);
+/** @brief @ref rd_sensor_dsp_fp */
+rd_status_t ri_dps310_dsp_get (uint8_t * dsp, uint8_t * parameter);
+/** @brief @ref rd_sensor_setup_fp */
+rd_status_t ri_dps310_mode_set (uint8_t * mode);
+/** @brief @ref rd_sensor_setup_fp */
+rd_status_t ri_dps310_mode_get (uint8_t * mode);
+/** @brief @ref rd_sensor_data_fp */
+rd_status_t ri_dps310_data_get (rd_sensor_data_t * const data);
+#endif

--- a/test/interfaces/environmental/test_ruuvi_interface_dps310.c
+++ b/test/interfaces/environmental/test_ruuvi_interface_dps310.c
@@ -130,8 +130,8 @@ void test_ri_dps310_samplerate_set_ok (void)
         // DEFAULT rate, 1/s
         if (0U == rate)
         {
-            p_ctx->temp_mr = 1U;
-            p_ctx->pres_mr = 1U;
+            p_ctx->temp_mr = DPS310_MR_1;
+            p_ctx->pres_mr = DPS310_MR_1;
             dps310_config_temp_ExpectAndReturn (dps_ctx.p_ctx,
                                                 DPS310_MR_1,
                                                 0,
@@ -390,11 +390,241 @@ void test_ri_dps310_scale_set_no_change (void)
     TEST_ASSERT (RD_SENSOR_CFG_DEFAULT == scale);
 }
 
+
+void test_ri_dps310_dsp_set_last (void)
+{
+    rd_status_t err_code = RD_SUCCESS;
+    // Run singleton test to initialize sensor context.
+    test_ri_dps310_init_singleton();
+    dps310_ctx_t * const p_ctx = (dps310_ctx_t *) dps_ctx.p_ctx;
+    p_ctx->device_status = DPS310_READY;
+    uint8_t dsp_func  = RD_SENSOR_DSP_LAST;
+    uint8_t dsp_param = RD_SENSOR_CFG_DEFAULT;
+    p_ctx->temp_osr = DPS310_OS_1;
+    p_ctx->pres_osr = DPS310_OS_1;
+    dps310_config_temp_ExpectAndReturn (dps_ctx.p_ctx,
+                                        0,
+                                        DPS310_OS_1,
+                                        DPS310_SUCCESS);
+    dps310_config_temp_IgnoreArg_temp_mr();
+    dps310_config_pres_ExpectAndReturn (dps_ctx.p_ctx,
+                                        0,
+                                        DPS310_OS_1,
+                                        DPS310_SUCCESS);
+    dps310_config_pres_IgnoreArg_pres_mr();
+    err_code = ri_dps310_dsp_set (&dsp_func, &dsp_param);
+    TEST_ASSERT (RD_SUCCESS == err_code);
+    TEST_ASSERT (RD_SENSOR_DSP_LAST == dsp_func);
+}
+
+
+void test_ri_dps310_dsp_set_os (void)
+{
+    rd_status_t err_code = RD_SUCCESS;
+    // Run singleton test to initialize sensor context.
+    test_ri_dps310_init_singleton();
+    // Take address of singleton context to simulate state updates in driver
+    dps310_ctx_t * const p_ctx = (dps310_ctx_t *) dps_ctx.p_ctx;
+    p_ctx->device_status = DPS310_READY;
+    uint8_t dsp_func = RD_SENSOR_DSP_OS;
+
+    for (uint8_t os = 0U; os < 129U; os ++)
+    {
+        uint8_t dsp_func = RD_SENSOR_DSP_OS;
+
+        // DEFAULT os, 1/s
+        if (0U == os)
+        {
+            p_ctx->temp_osr = DPS310_OS_1;
+            p_ctx->pres_osr = DPS310_OS_1;
+            dps310_config_temp_ExpectAndReturn (dps_ctx.p_ctx,
+                                                0,
+                                                DPS310_OS_1,
+                                                DPS310_SUCCESS);
+            dps310_config_temp_IgnoreArg_temp_mr();
+            dps310_config_pres_ExpectAndReturn (dps_ctx.p_ctx,
+                                                0,
+                                                DPS310_OS_1,
+                                                DPS310_SUCCESS);
+            dps310_config_pres_IgnoreArg_pres_mr();
+            ri_dps310_dsp_set (&dsp_func, &os);
+            TEST_ASSERT (1U == os);
+            os = 0;
+        }
+        else if (1U == os)
+        {
+            p_ctx->temp_osr = DPS310_OS_1;
+            p_ctx->pres_osr = DPS310_OS_1;
+            dps310_config_temp_ExpectAndReturn (dps_ctx.p_ctx,
+                                                0,
+                                                DPS310_OS_1,
+                                                DPS310_SUCCESS);
+            dps310_config_temp_IgnoreArg_temp_mr();
+            dps310_config_pres_ExpectAndReturn (dps_ctx.p_ctx,
+                                                0,
+                                                DPS310_OS_1,
+                                                DPS310_SUCCESS);
+            dps310_config_pres_IgnoreArg_pres_mr();
+            ri_dps310_dsp_set (&dsp_func, &os);
+            TEST_ASSERT (1U == os);
+        }
+        else if (2U == os)
+        {
+            p_ctx->temp_osr = DPS310_OS_2;
+            p_ctx->pres_osr = DPS310_OS_2;
+            dps310_config_temp_ExpectAndReturn (dps_ctx.p_ctx,
+                                                0,
+                                                DPS310_OS_2,
+                                                DPS310_SUCCESS);
+            dps310_config_temp_IgnoreArg_temp_mr();
+            dps310_config_pres_ExpectAndReturn (dps_ctx.p_ctx,
+                                                0,
+                                                DPS310_OS_2,
+                                                DPS310_SUCCESS);
+            dps310_config_pres_IgnoreArg_pres_mr();
+            ri_dps310_dsp_set (&dsp_func, &os);
+            TEST_ASSERT (2U == os);
+        }
+        else if (3U == os)
+        {
+            p_ctx->temp_osr = DPS310_OS_4;
+            p_ctx->pres_osr = DPS310_OS_4;
+            dps310_config_temp_ExpectAndReturn (dps_ctx.p_ctx,
+                                                0,
+                                                DPS310_OS_4,
+                                                DPS310_SUCCESS);
+            dps310_config_temp_IgnoreArg_temp_mr();
+            dps310_config_pres_ExpectAndReturn (dps_ctx.p_ctx,
+                                                0,
+                                                DPS310_OS_4,
+                                                DPS310_SUCCESS);
+            dps310_config_pres_IgnoreArg_pres_mr();
+            ri_dps310_dsp_set (&dsp_func, &os);
+            TEST_ASSERT (4U == os);
+        }
+        else if (5U == os)
+        {
+            p_ctx->temp_osr = DPS310_OS_8;
+            p_ctx->pres_osr = DPS310_OS_8;
+            dps310_config_temp_ExpectAndReturn (dps_ctx.p_ctx,
+                                                0,
+                                                DPS310_OS_8,
+                                                DPS310_SUCCESS);
+            dps310_config_temp_IgnoreArg_temp_mr();
+            dps310_config_pres_ExpectAndReturn (dps_ctx.p_ctx,
+                                                0,
+                                                DPS310_OS_8,
+                                                DPS310_SUCCESS);
+            dps310_config_pres_IgnoreArg_pres_mr();
+            ri_dps310_dsp_set (&dsp_func, &os);
+            TEST_ASSERT (8U == os);
+        }
+        else if (9U == os)
+        {
+            p_ctx->temp_osr = DPS310_OS_16;
+            p_ctx->pres_osr = DPS310_OS_16;
+            dps310_config_temp_ExpectAndReturn (dps_ctx.p_ctx,
+                                                0,
+                                                DPS310_OS_16,
+                                                DPS310_SUCCESS);
+            dps310_config_temp_IgnoreArg_temp_mr();
+            dps310_config_pres_ExpectAndReturn (dps_ctx.p_ctx,
+                                                0,
+                                                DPS310_OS_16,
+                                                DPS310_SUCCESS);
+            dps310_config_pres_IgnoreArg_pres_mr();
+            ri_dps310_dsp_set (&dsp_func, &os);
+            TEST_ASSERT (16U == os);
+        }
+        else if (17U == os)
+        {
+            p_ctx->temp_osr = DPS310_OS_32;
+            p_ctx->pres_osr = DPS310_OS_32;
+            dps310_config_temp_ExpectAndReturn (dps_ctx.p_ctx,
+                                                0,
+                                                DPS310_OS_32,
+                                                DPS310_SUCCESS);
+            dps310_config_temp_IgnoreArg_temp_mr();
+            dps310_config_pres_ExpectAndReturn (dps_ctx.p_ctx,
+                                                0,
+                                                DPS310_OS_32,
+                                                DPS310_SUCCESS);
+            dps310_config_pres_IgnoreArg_pres_mr();
+            ri_dps310_dsp_set (&dsp_func, &os);
+            TEST_ASSERT (32U == os);
+        }
+        else if (33U == os)
+        {
+            p_ctx->temp_osr = DPS310_OS_64;
+            p_ctx->pres_osr = DPS310_OS_64;
+            dps310_config_temp_ExpectAndReturn (dps_ctx.p_ctx,
+                                                0,
+                                                DPS310_OS_64,
+                                                DPS310_SUCCESS);
+            dps310_config_temp_IgnoreArg_temp_mr();
+            dps310_config_pres_ExpectAndReturn (dps_ctx.p_ctx,
+                                                0,
+                                                DPS310_OS_64,
+                                                DPS310_SUCCESS);
+            dps310_config_pres_IgnoreArg_pres_mr();
+            ri_dps310_dsp_set (&dsp_func, &os);
+            TEST_ASSERT (64U == os);
+        }
+        else if (65U == os)
+        {
+            p_ctx->temp_osr = DPS310_OS_128;
+            p_ctx->pres_osr = DPS310_OS_128;
+            dps310_config_temp_ExpectAndReturn (dps_ctx.p_ctx,
+                                                0,
+                                                DPS310_OS_128,
+                                                DPS310_SUCCESS);
+            dps310_config_temp_IgnoreArg_temp_mr();
+            dps310_config_pres_ExpectAndReturn (dps_ctx.p_ctx,
+                                                0,
+                                                DPS310_OS_128,
+                                                DPS310_SUCCESS);
+            dps310_config_pres_IgnoreArg_pres_mr();
+            ri_dps310_dsp_set (&dsp_func, &os);
+            TEST_ASSERT (128U == os);
+        }
+        else
+        {
+            err_code = ri_dps310_dsp_set (&dsp_func, &os);
+            TEST_ASSERT (RD_ERROR_NOT_SUPPORTED == err_code);
+        }
+    }
+}
+
+void test_ri_dps310_dsp_set_default (void)
+{
+    rd_status_t err_code = RD_SUCCESS;
+    // Run singleton test to initialize sensor context.
+    test_ri_dps310_init_singleton();
+    dps310_ctx_t * const p_ctx = (dps310_ctx_t *) dps_ctx.p_ctx;
+    p_ctx->device_status = DPS310_READY;
+    uint8_t dsp_func  = RD_SENSOR_CFG_DEFAULT;
+    uint8_t dsp_param = RD_SENSOR_CFG_DEFAULT;
+    p_ctx->temp_osr = DPS310_OS_1;
+    p_ctx->pres_osr = DPS310_OS_1;
+    dps310_config_temp_ExpectAndReturn (dps_ctx.p_ctx,
+                                        0,
+                                        DPS310_OS_1,
+                                        DPS310_SUCCESS);
+    dps310_config_temp_IgnoreArg_temp_mr();
+    dps310_config_pres_ExpectAndReturn (dps_ctx.p_ctx,
+                                        0,
+                                        DPS310_OS_1,
+                                        DPS310_SUCCESS);
+    dps310_config_pres_IgnoreArg_pres_mr();
+    err_code = ri_dps310_dsp_set (&dsp_func, &dsp_param);
+    TEST_ASSERT (RD_SUCCESS == err_code);
+    TEST_ASSERT (RD_SENSOR_DSP_LAST == dsp_func);
+    TEST_ASSERT (1U == dsp_param);
+}
+
+// DSP_GET is tested by setters.
 #if 0
 /** @brief @ref rd_sensor_dsp_fp */
-rd_status_t ri_dps310_dsp_set (uint8_t * dsp, uint8_t * parameter);
-/** @brief @ref rd_sensor_dsp_fp */
-rd_status_t ri_dps310_dsp_get (uint8_t * dsp, uint8_t * parameter);
 /** @brief @ref rd_sensor_setup_fp */
 rd_status_t ri_dps310_mode_set (uint8_t * mode);
 /** @brief @ref rd_sensor_setup_fp */

--- a/test/interfaces/environmental/test_ruuvi_interface_dps310.c
+++ b/test/interfaces/environmental/test_ruuvi_interface_dps310.c
@@ -116,11 +116,182 @@ void test_ri_dps310_uninit_null (void)
     TEST_ASSERT (RD_ERROR_NULL == err_code);
 }
 
-#if 0
-/** @brief @ref rd_sensor_setup_fp */
-rd_status_t ri_dps310_samplerate_set (uint8_t * samplerate);
+void test_ri_dps310_samplerate_set_ok (void)
+{
+    rd_status_t err_code = RD_SUCCESS;
+    // Run singleton test to initialize sensor context.
+    test_ri_dps310_init_singleton();
+    // Take address of singleton context to simulate state updates in driver
+    dps310_ctx_t * const p_ctx = (dps310_ctx_t *) dps_ctx.p_ctx;
+
+    for (uint8_t rate = 0U; rate < 129U; rate ++)
+    {
+        // DEFAULT rate, 1/s
+        if (0U == rate)
+        {
+            p_ctx->temp_mr = 1U;
+            p_ctx->pres_mr = 1U;
+            dps310_config_temp_ExpectAndReturn (dps_ctx.p_ctx,
+                                                DPS310_MR_1,
+                                                0,
+                                                DPS310_SUCCESS);
+            dps310_config_temp_IgnoreArg_temp_osr();
+            dps310_config_pres_ExpectAndReturn (dps_ctx.p_ctx,
+                                                DPS310_MR_1,
+                                                0,
+                                                DPS310_SUCCESS);
+            dps310_config_pres_IgnoreArg_pres_osr();
+            ri_dps310_samplerate_set (&rate);
+            TEST_ASSERT (1U == rate);
+            rate = 0;
+        }
+        else if (1U == rate)
+        {
+            p_ctx->temp_mr = DPS310_MR_1;
+            p_ctx->pres_mr = DPS310_MR_1;
+            dps310_config_temp_ExpectAndReturn (dps_ctx.p_ctx,
+                                                DPS310_MR_1,
+                                                0,
+                                                DPS310_SUCCESS);
+            dps310_config_temp_IgnoreArg_temp_osr();
+            dps310_config_pres_ExpectAndReturn (dps_ctx.p_ctx,
+                                                DPS310_MR_1,
+                                                0,
+                                                DPS310_SUCCESS);
+            dps310_config_pres_IgnoreArg_pres_osr();
+            ri_dps310_samplerate_set (&rate);
+            TEST_ASSERT (1U == rate);
+        }
+        else if (2U == rate)
+        {
+            p_ctx->temp_mr = DPS310_MR_2;
+            p_ctx->pres_mr = DPS310_MR_2;
+            dps310_config_temp_ExpectAndReturn (dps_ctx.p_ctx,
+                                                DPS310_MR_2,
+                                                0,
+                                                DPS310_SUCCESS);
+            dps310_config_temp_IgnoreArg_temp_osr();
+            dps310_config_pres_ExpectAndReturn (dps_ctx.p_ctx,
+                                                DPS310_MR_2,
+                                                0,
+                                                DPS310_SUCCESS);
+            dps310_config_pres_IgnoreArg_pres_osr();
+            ri_dps310_samplerate_set (&rate);
+            TEST_ASSERT (2U == rate);
+        }
+        else if (3U == rate)
+        {
+            p_ctx->temp_mr = DPS310_MR_4;
+            p_ctx->pres_mr = DPS310_MR_4;
+            dps310_config_temp_ExpectAndReturn (dps_ctx.p_ctx,
+                                                DPS310_MR_4,
+                                                0,
+                                                DPS310_SUCCESS);
+            dps310_config_temp_IgnoreArg_temp_osr();
+            dps310_config_pres_ExpectAndReturn (dps_ctx.p_ctx,
+                                                DPS310_MR_4,
+                                                0,
+                                                DPS310_SUCCESS);
+            dps310_config_pres_IgnoreArg_pres_osr();
+            ri_dps310_samplerate_set (&rate);
+            TEST_ASSERT (4U == rate);
+        }
+        else if (5U == rate)
+        {
+            p_ctx->temp_mr = DPS310_MR_8;
+            p_ctx->pres_mr = DPS310_MR_8;
+            dps310_config_temp_ExpectAndReturn (dps_ctx.p_ctx,
+                                                DPS310_MR_8,
+                                                0,
+                                                DPS310_SUCCESS);
+            dps310_config_temp_IgnoreArg_temp_osr();
+            dps310_config_pres_ExpectAndReturn (dps_ctx.p_ctx,
+                                                DPS310_MR_8,
+                                                0,
+                                                DPS310_SUCCESS);
+            dps310_config_pres_IgnoreArg_pres_osr();
+            ri_dps310_samplerate_set (&rate);
+            TEST_ASSERT (8U == rate);
+        }
+        else if (9U == rate)
+        {
+            p_ctx->temp_mr = DPS310_MR_16;
+            p_ctx->pres_mr = DPS310_MR_16;
+            dps310_config_temp_ExpectAndReturn (dps_ctx.p_ctx,
+                                                DPS310_MR_16,
+                                                0,
+                                                DPS310_SUCCESS);
+            dps310_config_temp_IgnoreArg_temp_osr();
+            dps310_config_pres_ExpectAndReturn (dps_ctx.p_ctx,
+                                                DPS310_MR_16,
+                                                0,
+                                                DPS310_SUCCESS);
+            dps310_config_pres_IgnoreArg_pres_osr();
+            ri_dps310_samplerate_set (&rate);
+            TEST_ASSERT (16U == rate);
+        }
+        else if (17U == rate)
+        {
+            p_ctx->temp_mr = DPS310_MR_32;
+            p_ctx->pres_mr = DPS310_MR_32;
+            dps310_config_temp_ExpectAndReturn (dps_ctx.p_ctx,
+                                                DPS310_MR_32,
+                                                0,
+                                                DPS310_SUCCESS);
+            dps310_config_temp_IgnoreArg_temp_osr();
+            dps310_config_pres_ExpectAndReturn (dps_ctx.p_ctx,
+                                                DPS310_MR_32,
+                                                0,
+                                                DPS310_SUCCESS);
+            dps310_config_pres_IgnoreArg_pres_osr();
+            ri_dps310_samplerate_set (&rate);
+            TEST_ASSERT (32U == rate);
+        }
+        else if (33U == rate)
+        {
+            p_ctx->temp_mr = DPS310_MR_64;
+            p_ctx->pres_mr = DPS310_MR_64;
+            dps310_config_temp_ExpectAndReturn (dps_ctx.p_ctx,
+                                                DPS310_MR_64,
+                                                0,
+                                                DPS310_SUCCESS);
+            dps310_config_temp_IgnoreArg_temp_osr();
+            dps310_config_pres_ExpectAndReturn (dps_ctx.p_ctx,
+                                                DPS310_MR_64,
+                                                0,
+                                                DPS310_SUCCESS);
+            dps310_config_pres_IgnoreArg_pres_osr();
+            ri_dps310_samplerate_set (&rate);
+            TEST_ASSERT (64U == rate);
+        }
+        else if (65U == rate)
+        {
+            p_ctx->temp_mr = DPS310_MR_128;
+            p_ctx->pres_mr = DPS310_MR_128;
+            dps310_config_temp_ExpectAndReturn (dps_ctx.p_ctx,
+                                                DPS310_MR_128,
+                                                0,
+                                                DPS310_SUCCESS);
+            dps310_config_temp_IgnoreArg_temp_osr();
+            dps310_config_pres_ExpectAndReturn (dps_ctx.p_ctx,
+                                                DPS310_MR_128,
+                                                0,
+                                                DPS310_SUCCESS);
+            dps310_config_pres_IgnoreArg_pres_osr();
+            ri_dps310_samplerate_set (&rate);
+            TEST_ASSERT (128U == rate);
+        }
+        else
+        {
+            err_code = ri_dps310_samplerate_set (&rate);
+            TEST_ASSERT (RD_ERROR_NOT_SUPPORTED == err_code);
+        }
+    }
+}
 /** @brief @ref rd_sensor_setup_fp */
 rd_status_t ri_dps310_samplerate_get (uint8_t * samplerate);
+
+#if 0
 /** @brief @ref rd_sensor_setup_fp */
 rd_status_t ri_dps310_resolution_set (uint8_t * resolution);
 /** @brief @ref rd_sensor_setup_fp */

--- a/test/interfaces/environmental/test_ruuvi_interface_dps310.c
+++ b/test/interfaces/environmental/test_ruuvi_interface_dps310.c
@@ -636,7 +636,7 @@ void test_ri_dps310_mode_set_single_ok (void)
     dps310_measure_temp_once_sync_IgnoreArg_result ();
     dps310_measure_pres_once_sync_ExpectAndReturn (p_ctx, NULL, DPS310_SUCCESS);
     dps310_measure_pres_once_sync_IgnoreArg_result ();
-    rd_sensor_timestamp_get_ExpectAndReturn(1000U);
+    rd_sensor_timestamp_get_ExpectAndReturn (1000U);
     err_code = ri_dps310_mode_set (&mode);
     TEST_ASSERT (RD_SENSOR_CFG_SLEEP == mode);
     TEST_ASSERT (RD_SUCCESS == err_code);
@@ -651,7 +651,7 @@ void test_ri_dps310_mode_set_continuous_ok (void)
     dps310_ctx_t * const p_ctx = (dps310_ctx_t *) dps_ctx.p_ctx;
     p_ctx->device_status = DPS310_READY;
     dps310_measure_continuous_async_ExpectAndReturn (p_ctx, DPS310_SUCCESS);
-    err_code = ri_dps310_mode_set(&mode);
+    err_code = ri_dps310_mode_set (&mode);
     TEST_ASSERT (RD_SUCCESS == err_code);
 }
 

--- a/test/interfaces/environmental/test_ruuvi_interface_dps310.c
+++ b/test/interfaces/environmental/test_ruuvi_interface_dps310.c
@@ -623,12 +623,42 @@ void test_ri_dps310_dsp_set_default (void)
 }
 
 // DSP_GET is tested by setters.
-#if 0
-/** @brief @ref rd_sensor_dsp_fp */
-/** @brief @ref rd_sensor_setup_fp */
+
+void test_ri_dps310_mode_set_single_ok (void)
+{
+    rd_status_t err_code = RD_SUCCESS;
+    // Run singleton test to initialize sensor context.
+    test_ri_dps310_init_singleton ();
+    dps310_ctx_t * const p_ctx = (dps310_ctx_t *) dps_ctx.p_ctx;
+    p_ctx->device_status = DPS310_READY;
+    uint8_t mode = RD_SENSOR_CFG_SINGLE;
+    dps310_measure_temp_once_sync_ExpectAndReturn (p_ctx, NULL, DPS310_SUCCESS);
+    dps310_measure_temp_once_sync_IgnoreArg_result ();
+    dps310_measure_pres_once_sync_ExpectAndReturn (p_ctx, NULL, DPS310_SUCCESS);
+    dps310_measure_pres_once_sync_IgnoreArg_result ();
+    rd_sensor_timestamp_get_ExpectAndReturn(1000U);
+    err_code = ri_dps310_mode_set (&mode);
+    TEST_ASSERT (RD_SENSOR_CFG_SLEEP == mode);
+    TEST_ASSERT (RD_SUCCESS == err_code);
+}
+
+void test_ri_dps310_mode_set_continuous_ok (void)
+{
+    rd_status_t err_code = RD_SUCCESS;
+    uint8_t mode = RD_SENSOR_CFG_CONTINUOUS;
+    // Run singleton test to initialize sensor context.
+    test_ri_dps310_init_singleton();
+    dps310_ctx_t * const p_ctx = (dps310_ctx_t *) dps_ctx.p_ctx;
+    p_ctx->device_status = DPS310_READY;
+    dps310_measure_continuous_async_ExpectAndReturn (p_ctx, DPS310_SUCCESS);
+    err_code = ri_dps310_mode_set(&mode);
+    TEST_ASSERT (RD_SUCCESS == err_code);
+}
+
 rd_status_t ri_dps310_mode_set (uint8_t * mode);
 /** @brief @ref rd_sensor_setup_fp */
-rd_status_t ri_dps310_mode_get (uint8_t * mode);
-/** @brief @ref rd_sensor_data_fp */
+
+// MODE_GET is tested by setters
+#if 0
 rd_status_t ri_dps310_data_get (rd_sensor_data_t * const data);
 #endif

--- a/test/interfaces/environmental/test_ruuvi_interface_dps310.c
+++ b/test/interfaces/environmental/test_ruuvi_interface_dps310.c
@@ -47,8 +47,8 @@ void test_ri_dps310_init_ok (void)
     };
     dps_ctx.p_ctx = &init_ctx;
     rd_sensor_is_init_ExpectAndReturn (&dps_ctx, false);
-    dps310_init_ExpectAndReturn (&init_ctx, DPS310_SUCCESS);
     rd_sensor_initialize_Expect (&dps_ctx);
+    dps310_init_ExpectAndReturn (&init_ctx, DPS310_SUCCESS);
     rd_status_t err_code = ri_dps310_init (&dps_ctx, RD_BUS_SPI, 1U);
     TEST_ASSERT (RD_SUCCESS == err_code);
     TEST_ASSERT (&ri_dps310_init == dps_ctx.init);
@@ -70,9 +70,9 @@ void test_ri_dps310_init_ok (void)
 void test_ri_dps310_init_singleton (void)
 {
     rd_sensor_is_init_ExpectAndReturn (&dps_ctx, false);
+    rd_sensor_initialize_Expect (&dps_ctx);
     dps310_init_ExpectAndReturn (NULL, DPS310_SUCCESS);
     dps310_init_IgnoreArg_ctx();
-    rd_sensor_initialize_Expect (&dps_ctx);
     rd_status_t err_code = ri_dps310_init (&dps_ctx, RD_BUS_SPI, 1U);
     TEST_ASSERT (RD_SUCCESS == err_code);
     TEST_ASSERT (&ri_dps310_init == dps_ctx.init);
@@ -98,6 +98,7 @@ void test_ri_dps310_init_singleton (void)
 void test_ri_dps310_init_singleton_i2c_notimpl (void)
 {
     rd_sensor_is_init_ExpectAndReturn (&dps_ctx, false);
+    rd_sensor_initialize_Expect (&dps_ctx);
     rd_status_t err_code = ri_dps310_init (&dps_ctx, RD_BUS_I2C, 1U);
     TEST_ASSERT (RD_ERROR_NOT_IMPLEMENTED == err_code);
 }
@@ -105,6 +106,7 @@ void test_ri_dps310_init_singleton_i2c_notimpl (void)
 void test_ri_dps310_init_singleton_uart_notsupp (void)
 {
     rd_sensor_is_init_ExpectAndReturn (&dps_ctx, false);
+    rd_sensor_initialize_Expect (&dps_ctx);
     rd_status_t err_code = ri_dps310_init (&dps_ctx, RD_BUS_UART, 1U);
     TEST_ASSERT (RD_ERROR_NOT_SUPPORTED == err_code);
 }

--- a/test/interfaces/spi/test_ruuvi_interface_spi_dps310.c
+++ b/test/interfaces/spi/test_ruuvi_interface_spi_dps310.c
@@ -1,6 +1,8 @@
 #include "unity.h"
 
 #include "ruuvi_interface_spi_dps310.h"
+#include "mock_ruuvi_interface_gpio.h"
+#include "mock_ruuvi_interface_spi.h"
 
 void setUp (void)
 {
@@ -10,7 +12,50 @@ void tearDown (void)
 {
 }
 
-void test_ruuvi_interface_spi_dps310_NeedToImplement (void)
+/**
+ * @brief SPI write function for DPS310
+ *
+ * Binds Ruuvi Interface SPI functions into Ruuvi's DPS310 driver.
+ * Handles GPIO chip select, there is no forced delay to let the CS settle.
+ *
+ * @param[in] dev_id @ref SPI interface handle, i.e. pin number of the chip select pin of DPS310.
+ * @param[in] reg_addr DPS310 register address to write.
+ * @param[in] p_reg_data pointer to data to be written.
+ * @param[in] len length of data to be written.
+ **/
+void test_ri_spi_dps310_write (void)
 {
-    TEST_IGNORE_MESSAGE ("Need to Implement ruuvi_interface_spi_dps310");
+    uint32_t gpio_handle = 33U;
+    uint8_t data[] = {1, 2, 3, 4, 5, 6, 7, 8};
+    uint8_t reg_addr = 0x01U;
+    ri_gpio_write_ExpectAndReturn (0x101U, RI_GPIO_LOW, RD_SUCCESS);
+    ri_spi_xfer_blocking_ExpectWithArrayAndReturn (&reg_addr, 1, 1, NULL, 0, 0, RD_SUCCESS);
+    ri_spi_xfer_blocking_ExpectWithArrayAndReturn (data, 8, 8, NULL, 0, 0, RD_SUCCESS);
+    ri_gpio_write_ExpectAndReturn (0x101U, RI_GPIO_HIGH, RD_SUCCESS);
+    uint32_t retval = ri_spi_dps310_write (&gpio_handle, reg_addr, data, sizeof (data));
+    TEST_ASSERT (0 == retval);
 }
+/**
+ * @brief SPI Read function for DPS310
+ *
+ * Binds Ruuvi Interface SPI functions into Ruuvi DPS310 driver.
+ * Handles GPIO chip select, there is no forced delay to let the CS settle.
+ *
+ * @param[in] dev_id @ref SPI interface handle, i.e. pin number of the chip select pin of DPS310.
+ * @param[in] reg_addr DPS310 register address to read.
+ * @param[in] p_reg_data pointer to data to be received.
+ * @param[in] len length of data to be received.
+ **/
+void test_ri_spi_dps310_read (void)
+{
+    uint8_t gpio_handle = 33U;
+    uint8_t data[8] = {0};
+    uint8_t reg_addr = 0x01U;
+    ri_gpio_write_ExpectAndReturn (0x101U, RI_GPIO_LOW, RD_SUCCESS);
+    ri_spi_xfer_blocking_ExpectWithArrayAndReturn (&reg_addr, 1, 1, NULL, 0, 0, RD_SUCCESS);
+    ri_spi_xfer_blocking_ExpectAndReturn (NULL, 0, data, 8, RD_SUCCESS);
+    ri_gpio_write_ExpectAndReturn (0x101U, RI_GPIO_HIGH, RD_SUCCESS);
+    uint32_t retval = ri_spi_dps310_read (&gpio_handle, reg_addr, data, sizeof (data));
+    TEST_ASSERT (0 == retval);
+}
+/** @} */

--- a/test/interfaces/spi/test_ruuvi_interface_spi_dps310.c
+++ b/test/interfaces/spi/test_ruuvi_interface_spi_dps310.c
@@ -1,0 +1,16 @@
+#include "unity.h"
+
+#include "ruuvi_interface_spi_dps310.h"
+
+void setUp (void)
+{
+}
+
+void tearDown (void)
+{
+}
+
+void test_ruuvi_interface_spi_dps310_NeedToImplement (void)
+{
+    TEST_IGNORE_MESSAGE ("Need to Implement ruuvi_interface_spi_dps310");
+}


### PR DESCRIPTION
Work in progress, needs SPI implementation and data get. Opening PR to check CI status.

This supports the same features as BME280 driver, i.e. interrupts and FIFO aren't supported. 