### PR TITLE
Interrupt context detection

### DIFF
--- a/src/interfaces/yield/ruuvi_interface_yield.h
+++ b/src/interfaces/yield/ruuvi_interface_yield.h
@@ -112,6 +112,16 @@ rd_status_t ri_delay_ms (uint32_t time);
   **/
 rd_status_t ri_delay_us (uint32_t time);
 
+/**
+  * @brief Check if current execution is in interrupt context.
+  *
+  * This function reads Interrupt Control and State Register (ICSR) to determine the
+  * interrupt status. The register is masked with VECTACTIVE mask.
+  *
+  * @return true if executrion is currently in interrupt context, false otherwise.
+  **/
+bool ri_yield_is_interrupt_context (void);
+
 /*@}*/
 
 #endif

--- a/src/nrf5_sdk15_platform/yield/ruuvi_nrf5_sdk15_yield.c
+++ b/src/nrf5_sdk15_platform/yield/ruuvi_nrf5_sdk15_yield.c
@@ -88,6 +88,13 @@ static void wakeup_handler (void * p_context)
     m_wakeup = true;
 }
 
+// Test if in interrupt mode
+bool ri_yield_is_interrupt_context (void)
+{
+    return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) != 0;
+}
+
+
 rd_status_t ri_yield_init (void)
 {
     fpu_init();
@@ -142,6 +149,7 @@ rd_status_t ri_yield (void)
 
     return RD_SUCCESS;
 }
+
 
 rd_status_t ri_delay_ms (uint32_t time)
 {

--- a/src/nrf5_sdk15_platform/yield/ruuvi_nrf5_sdk15_yield.c
+++ b/src/nrf5_sdk15_platform/yield/ruuvi_nrf5_sdk15_yield.c
@@ -150,7 +150,6 @@ rd_status_t ri_yield (void)
     return RD_SUCCESS;
 }
 
-
 rd_status_t ri_delay_ms (uint32_t time)
 {
     rd_status_t err_code = RD_SUCCESS;


### PR DESCRIPTION
Defined a function to monitor interrupt context. Resolves #139 