### PR TITLE
Fix delay crash

### DIFF
--- a/src/interfaces/yield/ruuvi_interface_yield.h
+++ b/src/interfaces/yield/ruuvi_interface_yield.h
@@ -112,6 +112,16 @@ rd_status_t ri_delay_ms (uint32_t time);
   **/
 rd_status_t ri_delay_us (uint32_t time);
 
+/**
+  * @brief Check if current execution is in interrupt context.
+  *
+  * This function reads Interrupt Control and State Register (ICSR) to determine the
+  * interrupt status. The register is masked with VECTACTIVE mask.
+  *
+  * @return true if executrion is currently in interrupt context, false otherwise.
+  **/
+bool ri_yield_is_interrupt_context (void);
+
 /*@}*/
 
 #endif

--- a/src/interfaces/yield/ruuvi_interface_yield.h
+++ b/src/interfaces/yield/ruuvi_interface_yield.h
@@ -118,7 +118,7 @@ rd_status_t ri_delay_us (uint32_t time);
   * This function reads Interrupt Control and State Register (ICSR) to determine the
   * interrupt status. The register is masked with VECTACTIVE mask.
   *
-  * @return true if executrion is currently in interrupt context, false otherwise.
+  * @return true if execution is currently in interrupt context, false otherwise.
   **/
 bool ri_yield_is_interrupt_context (void);
 

--- a/src/nrf5_sdk15_platform/flash/ruuvi_nrf5_sdk15_flash.c
+++ b/src/nrf5_sdk15_platform/flash/ruuvi_nrf5_sdk15_flash.c
@@ -532,7 +532,6 @@ rd_status_t ri_flash_uninit (void)
 /** Erase FDS */
 void ri_flash_purge (void)
 {
-    uint32_t ms = 200;
     ret_code_t rc = NRF_SUCCESS;
 #if   defined(NRF51)
     const int erase_unit = 1024;
@@ -546,16 +545,7 @@ void ri_flash_purge (void)
     {
         int page = (FSTORAGE_SECTION_START / erase_unit) + p; // erase unit == virtual page size
         rc = sd_flash_page_erase (page);
-
-        if (ri_yield_is_interrupt_context)
-        {
-            ri_delay_us (1000 * ms);
-        }
-        else
-        {
-            ri_delay_ms (ms);
-        }
-
+        ri_delay_ms (200);
         RD_ERROR_CHECK (rc, RD_SUCCESS);
     }
 }

--- a/src/nrf5_sdk15_platform/flash/ruuvi_nrf5_sdk15_flash.c
+++ b/src/nrf5_sdk15_platform/flash/ruuvi_nrf5_sdk15_flash.c
@@ -545,7 +545,7 @@ void ri_flash_purge (void)
     {
         int page = (FSTORAGE_SECTION_START / erase_unit) + p; // erase unit == virtual page size
         rc = sd_flash_page_erase (page);
-        ri_delay_ms (200);
+        ri_delay_us (200000);
         RD_ERROR_CHECK (rc, RD_SUCCESS);
     }
 }

--- a/src/nrf5_sdk15_platform/flash/ruuvi_nrf5_sdk15_flash.c
+++ b/src/nrf5_sdk15_platform/flash/ruuvi_nrf5_sdk15_flash.c
@@ -532,6 +532,7 @@ rd_status_t ri_flash_uninit (void)
 /** Erase FDS */
 void ri_flash_purge (void)
 {
+    uint32_t ms = 200;
     ret_code_t rc = NRF_SUCCESS;
 #if   defined(NRF51)
     const int erase_unit = 1024;
@@ -545,7 +546,16 @@ void ri_flash_purge (void)
     {
         int page = (FSTORAGE_SECTION_START / erase_unit) + p; // erase unit == virtual page size
         rc = sd_flash_page_erase (page);
-        ri_delay_us (200000);
+
+        if (ri_yield_is_interrupt_context)
+        {
+            ri_delay_us (1000 * ms);
+        }
+        else
+        {
+            ri_delay_ms (ms);
+        }
+
         RD_ERROR_CHECK (rc, RD_SUCCESS);
     }
 }

--- a/src/nrf5_sdk15_platform/yield/ruuvi_nrf5_sdk15_yield.c
+++ b/src/nrf5_sdk15_platform/yield/ruuvi_nrf5_sdk15_yield.c
@@ -155,19 +155,22 @@ rd_status_t ri_delay_ms (uint32_t time)
     rd_status_t err_code = RD_SUCCESS;
 #if RUUVI_NRF5_SDK15_TIMER_ENABLED
 
+    // Check that low-power delay is enabled and sleep timer is not running right now.
     if (m_lp && m_wakeup)
     {
-        m_wakeup = false;
-        err_code |= ri_timer_start (wakeup_timer, time, NULL);
-
-        if (ri_yield_is_interrupt_context)
+        if (ri_yield_is_interrupt_context())
         {
             ri_delay_us (1000 * time);
         }
-
-        while (RD_SUCCESS == err_code && !m_wakeup)
+        else
         {
-            err_code |= ri_yield();
+            m_wakeup = false;
+            err_code |= ri_timer_start (wakeup_timer, time, NULL);
+
+            while (RD_SUCCESS == err_code && !m_wakeup)
+            {
+                err_code |= ri_yield();
+            }
         }
     }
 

--- a/src/nrf5_sdk15_platform/yield/ruuvi_nrf5_sdk15_yield.c
+++ b/src/nrf5_sdk15_platform/yield/ruuvi_nrf5_sdk15_yield.c
@@ -160,6 +160,11 @@ rd_status_t ri_delay_ms (uint32_t time)
         m_wakeup = false;
         err_code |= ri_timer_start (wakeup_timer, time, NULL);
 
+        if (ri_yield_is_interrupt_context)
+        {
+            ri_delay_us (1000 * time);
+        }
+
         while (RD_SUCCESS == err_code && !m_wakeup)
         {
             err_code |= ri_yield();

--- a/src/nrf5_sdk15_platform/yield/ruuvi_nrf5_sdk15_yield.c
+++ b/src/nrf5_sdk15_platform/yield/ruuvi_nrf5_sdk15_yield.c
@@ -88,6 +88,13 @@ static void wakeup_handler (void * p_context)
     m_wakeup = true;
 }
 
+// Test if in interrupt mode
+bool ri_yield_is_interrupt_context (void)
+{
+    return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) != 0;
+}
+
+
 rd_status_t ri_yield_init (void)
 {
     fpu_init();
@@ -142,6 +149,7 @@ rd_status_t ri_yield (void)
 
     return RD_SUCCESS;
 }
+
 
 rd_status_t ri_delay_ms (uint32_t time)
 {

--- a/src/nrf5_sdk15_platform/yield/ruuvi_nrf5_sdk15_yield.c
+++ b/src/nrf5_sdk15_platform/yield/ruuvi_nrf5_sdk15_yield.c
@@ -150,7 +150,6 @@ rd_status_t ri_yield (void)
     return RD_SUCCESS;
 }
 
-
 rd_status_t ri_delay_ms (uint32_t time)
 {
     rd_status_t err_code = RD_SUCCESS;

--- a/src/nrf5_sdk15_platform/yield/ruuvi_nrf5_sdk15_yield.c
+++ b/src/nrf5_sdk15_platform/yield/ruuvi_nrf5_sdk15_yield.c
@@ -88,7 +88,6 @@ static void wakeup_handler (void * p_context)
     m_wakeup = true;
 }
 
-// Test if in interrupt mode
 bool ri_yield_is_interrupt_context (void)
 {
     return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) != 0;


### PR DESCRIPTION
Fixing the crash issue on calling `ri_flash_purge();` function. Crash is due to the power management interrupt. Fixed by replacing `delay_ms` function with `delay_us`. Additionally added function to check the interrupt occurrence.
Resolves #138
Resolves #139 