### PR TITLE
Use ri_gpio_id_t in parameters instead of uint16_t

### DIFF
--- a/src/tasks/ruuvi_task_led.c
+++ b/src/tasks/ruuvi_task_led.c
@@ -69,7 +69,7 @@ static inline ri_gpio_state_t led_to_pin_state (ri_gpio_id_t led, bool active)
     return state;
 }
 
-rd_status_t rt_led_init (const uint16_t * const leds,
+rd_status_t rt_led_init (const ri_gpio_id_t * const leds,
                          const ri_gpio_state_t * const active_states,
                          const size_t num_leds)
 {
@@ -123,7 +123,7 @@ rd_status_t rt_led_uninit (void)
     return err_code;
 }
 
-rd_status_t rt_led_write (const uint16_t led, const bool active)
+rd_status_t rt_led_write (const ri_gpio_id_t led, const bool active)
 {
     rd_status_t err_code = RD_SUCCESS;
 
@@ -150,7 +150,7 @@ void rt_led_activity_indicate (const bool active)
     (void) rt_led_write (m_activity_led, active);
 }
 
-rd_status_t rt_led_activity_led_set (uint16_t led)
+rd_status_t rt_led_activity_led_set (ri_gpio_id_t led)
 {
     rd_status_t err_code = RD_SUCCESS;
 
@@ -185,7 +185,7 @@ void rt_led_blink_isr (void * const p_context)
     active = !active;
 }
 
-rd_status_t rt_led_blink_start (const uint16_t led, const uint16_t interval_ms)
+rd_status_t rt_led_blink_start (const ri_gpio_id_t led, const uint16_t interval_ms)
 {
     rd_status_t err_code = RD_SUCCESS;
 
@@ -222,7 +222,7 @@ rd_status_t rt_led_blink_start (const uint16_t led, const uint16_t interval_ms)
     return err_code;
 }
 
-rd_status_t rt_led_blink_stop (const uint16_t led)
+rd_status_t rt_led_blink_stop (const ri_gpio_id_t led)
 {
     rd_status_t err_code = RD_SUCCESS;
 

--- a/src/tasks/ruuvi_task_led.h
+++ b/src/tasks/ruuvi_task_led.h
@@ -70,7 +70,7 @@
  * @warning Behaviour is undefined if led list and state list are o different size
  *          than num_leds.
  **/
-rd_status_t rt_led_init (const uint16_t * const leds,
+rd_status_t rt_led_init (const ri_gpio_id_t * const leds,
                          const ri_gpio_state_t * const active_states,
                          const size_t num_leds);
 
@@ -95,7 +95,7 @@ rd_status_t rt_led_uninit (void);
  * @retval RD_ERROR_INVALID_PARAM  if GPIO pin is not led.
  * @retval RD_ERROR_INVALID_STATE if GPIO task is not initialized.
  **/
-rd_status_t rt_led_write (const uint16_t led, const bool state);
+rd_status_t rt_led_write (const ri_gpio_id_t led, const bool state);
 
 /**
  * @brief Function to indicate activity in program.
@@ -119,7 +119,7 @@ void rt_led_activity_indicate (const bool state);
  * @retval RD_SUCCESS if valid led was set.
  * @retval RD_ERROR_INVALID_PARAM if there is no pin in LED.
  */
-rd_status_t rt_led_activity_led_set (const uint16_t led);
+rd_status_t rt_led_activity_led_set (const ri_gpio_id_t led);
 
 /**
  * @brief Get LED which is used to indicate activity.
@@ -144,7 +144,7 @@ uint16_t rt_led_activity_led_get (void);
  * @retval RD_ERROR_RESOURCES If timer cannot be allocated.
  * @retval RD_ERROR_INVALID_PARAM If there is no pin in LED.
  */
-rd_status_t rt_led_blink_start (const uint16_t led, const uint16_t interval_ms);
+rd_status_t rt_led_blink_start (const ri_gpio_id_t led, const uint16_t interval_ms);
 
 /**
  * @brief Stop blinking led and leave the pin as high-drive output in inactive state.
@@ -155,7 +155,7 @@ rd_status_t rt_led_blink_start (const uint16_t led, const uint16_t interval_ms);
  * @retval RD_SUCCESS Blinking was stopped.
  * @retval RD_ERROR_INVALID_STATE If given LED is not blinking.
  */
-rd_status_t rt_led_blink_stop (const uint16_t led);
+rd_status_t rt_led_blink_stop (const ri_gpio_id_t led);
 
 /**
  * @brief Check if LED task has been initialized.


### PR DESCRIPTION
Using ri_gpio_id_t for led variables in function parameters instead of uint16_t.

Resolves #135 
