### PR TITLE
Add Manufacturer ID Parser for BLE Scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## 3.4.5 - in progress
+## 3.4.5
  - Fix GPIO port mapping on NRF5 SDK 15 when port > 0.
  - Fix Flash erase not clearing out everything on nRF5 SDK15.
  - Add +3 RH offset to BME280 to fix offset observed in devices.

--- a/src/interfaces/communication/ruuvi_interface_communication_ble_advertising.h
+++ b/src/interfaces/communication/ruuvi_interface_communication_ble_advertising.h
@@ -239,7 +239,7 @@ rd_status_t ri_adv_channels_enable (const ri_radio_channels_t channel);
  * @return BLE Manufacturer ID, e.g. 0x0499 for Ruuvi Innovation
  */
 
-uint16_t ri_comm_ble_adv_parse_manuid (const uint8_t * const data,
+uint16_t ri_adv_parse_manuid (const uint8_t * const data,
                                        const size_t data_length);
 
 #endif

--- a/src/interfaces/communication/ruuvi_interface_communication_ble_advertising.h
+++ b/src/interfaces/communication/ruuvi_interface_communication_ble_advertising.h
@@ -230,4 +230,16 @@ rd_status_t ri_adv_scan_stop (void);
  */
 rd_status_t ri_adv_channels_enable (const ri_radio_channels_t channel);
 
+/**
+ * @brief Parse Manufacturer ID from given Bluetooth scan data.
+ *
+ * @params[in] data pointer to data to parse
+ * @params[in] data_length length of data to parse
+ * @retval 0 if argument is NULL of manufacturer ID not found
+ * @return BLE Manufacturer ID, e.g. 0x0499 for Ruuvi Innovation
+ */
+
+uint16_t ri_comm_ble_adv_parse_manuid (const uint8_t * const data,
+                                       const size_t data_length);
+
 #endif

--- a/src/interfaces/communication/ruuvi_interface_communication_ble_advertising.h
+++ b/src/interfaces/communication/ruuvi_interface_communication_ble_advertising.h
@@ -240,6 +240,6 @@ rd_status_t ri_adv_channels_enable (const ri_radio_channels_t channel);
  */
 
 uint16_t ri_adv_parse_manuid (const uint8_t * const data,
-                                       const size_t data_length);
+                              const size_t data_length);
 
 #endif

--- a/src/nrf5_sdk15_platform/communication/ruuvi_nrf5_sdk15_communication_ble_advertising.c
+++ b/src/nrf5_sdk15_platform/communication/ruuvi_nrf5_sdk15_communication_ble_advertising.c
@@ -772,4 +772,13 @@ rd_status_t ri_adv_stop()
     return RD_SUCCESS;
 }
 
+uint16_t ri_comm_ble_adv_parse_manuid (const uint8_t * const data,
+                                       const size_t data_length)
+{
+    uint16_t * manuf_id;
+    manuf_id = ble_advdata_parse (data, data_length,
+                                  BLE_GAP_AD_TYPE_MANUFACTURER_SPECIFIC_DATA);
+    return  *manuf_id;
+}
+
 #endif

--- a/src/nrf5_sdk15_platform/communication/ruuvi_nrf5_sdk15_communication_ble_advertising.c
+++ b/src/nrf5_sdk15_platform/communication/ruuvi_nrf5_sdk15_communication_ble_advertising.c
@@ -775,10 +775,18 @@ rd_status_t ri_adv_stop()
 uint16_t ri_comm_ble_adv_parse_manuid (const uint8_t * const data,
                                        const size_t data_length)
 {
-    uint16_t * manuf_id;
-    manuf_id = ble_advdata_parse (data, data_length,
-                                  BLE_GAP_AD_TYPE_MANUFACTURER_SPECIFIC_DATA);
-    return  *manuf_id;
+    uint8_t * manuf_id;
+    manuf_id = ble_advdata_parse ( (char *) data, data_length,
+                                   BLE_GAP_AD_TYPE_MANUFACTURER_SPECIFIC_DATA);
+
+    if (manuf_id == NULL)
+    {
+        return 0;
+    }
+    else
+    {
+        return (manuf_id[1] << 8 | manuf_id[0]);
+    }
 }
 
 #endif

--- a/src/nrf5_sdk15_platform/communication/ruuvi_nrf5_sdk15_communication_ble_advertising.c
+++ b/src/nrf5_sdk15_platform/communication/ruuvi_nrf5_sdk15_communication_ble_advertising.c
@@ -772,7 +772,7 @@ rd_status_t ri_adv_stop()
     return RD_SUCCESS;
 }
 
-uint16_t ri_comm_ble_adv_parse_manuid (const uint8_t * const data,
+uint16_t ri_adv_parse_manuid (const uint8_t * const data,
                                        const size_t data_length)
 {
     uint8_t * manuf_id;

--- a/src/nrf5_sdk15_platform/communication/ruuvi_nrf5_sdk15_communication_ble_advertising.c
+++ b/src/nrf5_sdk15_platform/communication/ruuvi_nrf5_sdk15_communication_ble_advertising.c
@@ -773,7 +773,7 @@ rd_status_t ri_adv_stop()
 }
 
 uint16_t ri_adv_parse_manuid (const uint8_t * const data,
-                                       const size_t data_length)
+                              const size_t data_length)
 {
     uint8_t * manuf_id;
     manuf_id = ble_advdata_parse ( (char *) data, data_length,


### PR DESCRIPTION
A manufacturer ID parser to help identify BLE advertising devices of Ruuvi Innovations.