### PR TITLE
Disconnect GATT on pairing error

### DIFF
--- a/.github/workflows/ceedling.yml
+++ b/.github/workflows/ceedling.yml
@@ -21,8 +21,8 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
-        with:
-          submodules: recursive
+      with:
+        submodules: recursive
 
     - name: Set up Ruby 2.6
       uses: actions/setup-ruby@v1

--- a/.github/workflows/ceedling.yml
+++ b/.github/workflows/ceedling.yml
@@ -21,9 +21,8 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
-
-    - name: Checkout submodules
-      uses: textbook/git-checkout-submodule-action@2.1.1
+        with:
+          submodules: recursive
 
     - name: Set up Ruby 2.6
       uses: actions/setup-ruby@v1

--- a/.github/workflows/gh-pages-check.yml
+++ b/.github/workflows/gh-pages-check.yml
@@ -19,10 +19,9 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
-
-    - name: Checkout submodules
-      uses: textbook/git-checkout-submodule-action@2.1.1
-
+        with:
+          submodules: recursive
+          
     # Install Doxygen
     - name: Install Doxygen
       run: sudo apt-get install -qq doxygen 

--- a/.github/workflows/gh-pages-check.yml
+++ b/.github/workflows/gh-pages-check.yml
@@ -19,9 +19,9 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
-        with:
-          submodules: recursive
-          
+      with:
+        ubmodules: recursive
+
     # Install Doxygen
     - name: Install Doxygen
       run: sudo apt-get install -qq doxygen 

--- a/.github/workflows/gh-pages-push.yml
+++ b/.github/workflows/gh-pages-push.yml
@@ -19,9 +19,8 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
-
-    - name: Checkout submodules
-      uses: textbook/git-checkout-submodule-action@2.1.1
+        with:
+          submodules: recursive
 
 
     # Install Doxygen

--- a/.github/workflows/gh-pages-push.yml
+++ b/.github/workflows/gh-pages-push.yml
@@ -19,8 +19,8 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
-        with:
-          submodules: recursive
+      with:
+        submodules: recursive
 
 
     # Install Doxygen

--- a/.github/workflows/pvs-check.yml
+++ b/.github/workflows/pvs-check.yml
@@ -19,8 +19,8 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
-        with:
-          submodules: recursive
+      with:
+        submodules: recursive
 
     # Generate folder for PVS report
     - name: mkdir

--- a/.github/workflows/pvs-check.yml
+++ b/.github/workflows/pvs-check.yml
@@ -19,9 +19,8 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
-
-    - name: Checkout submodules
-      uses: textbook/git-checkout-submodule-action@2.1.1
+        with:
+          submodules: recursive
 
     # Generate folder for PVS report
     - name: mkdir

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -20,9 +20,8 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
-
-    - name: Checkout submodules
-      uses: textbook/git-checkout-submodule-action@2.1.1
+        with:
+          submodules: recursive
 
     - name: Set up Sonar Scanner 4.40
       run: |

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -20,8 +20,8 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
-        with:
-          submodules: recursive
+      with:
+        submodules: recursive
 
     - name: Set up Sonar Scanner 4.40
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 3.9.3 (In progress)
  - Fix flash resource leak on unexpected size.
+ - Fix fatal error on attempted BLE bonding.
 
 ## 3.9.2
  - Fix GATT timer-related errors

--- a/src/nrf5_sdk15_platform/communication/ruuvi_nrf5_sdk15_communication_ble_gatt.c
+++ b/src/nrf5_sdk15_platform/communication/ruuvi_nrf5_sdk15_communication_ble_gatt.c
@@ -363,7 +363,15 @@ static void ble_evt_handler (ble_evt_t const * p_ble_evt, void * p_context)
                                                     BLE_GAP_SEC_STATUS_PAIRING_NOT_SUPP,
                                                     NULL, NULL);
             RD_ERROR_CHECK (ruuvi_nrf5_sdk15_to_ruuvi_error (err_code),
-                            RD_SUCCESS);
+                            ~RD_SUCCESS);
+
+            if (NRF_ERROR_INVALID_STATE == err_code)
+            {
+                err_code = sd_ble_gap_disconnect (p_ble_evt->evt.gattc_evt.conn_handle,
+                                                  BLE_HCI_REMOTE_USER_TERMINATED_CONNECTION);
+                LOG ("BLE GATT Disconnected\r\n");
+            }
+
             break;
 
         case BLE_GATTS_EVT_SYS_ATTR_MISSING:

--- a/src/ruuvi_driver_enabled_modules.h
+++ b/src/ruuvi_driver_enabled_modules.h
@@ -18,7 +18,7 @@
 #define RUUVI_DRIVER_ENABLED_MODULES_H
 
 /** @brief SemVer string, must match latest tag. */
-#define RUUVI_DRIVERS_SEMVER "3.9.2"
+#define RUUVI_DRIVERS_SEMVER "3.9.3"
 
 #ifdef CEEDLING
 #  define ENABLE_DEFAULT 1


### PR DESCRIPTION
An error check is improved to prevent application run blocking during the Android pairing process.

On `Invalid State` error, the application disconnects the GATT communication and logs the process to the user.

Possibly solves https://github.com/ruuvi/ruuvi.firmware.c/issues/281 